### PR TITLE
docs(adr): capture branching strategy and multi-source blog decisions

### DIFF
--- a/docs/adr/ADR-2026-04-21-adopt-feature-dev-main-branching.md
+++ b/docs/adr/ADR-2026-04-21-adopt-feature-dev-main-branching.md
@@ -1,0 +1,46 @@
+---
+id: ADR-2026-04-21-adopt-feature-dev-main-branching
+title: Adopt feature → dev → main branching strategy
+status: accepted
+date: 2026-04-21
+deciders: [thom]
+tags: [workflow, ci, conventions]
+supersedes: []
+superseded_by: []
+related: []
+source: retroactive capture of PR #38 (chore/ci-branches)
+---
+
+## Context
+
+CI was previously wired to a non-existent `staging` branch, so PR and push triggers fired on nothing and builds never ran. Fixing CI meant deciding what branches it should target, which forced an explicit branching strategy for the repo. Before this, the convention was implicit — some PRs went to `main`, `staging` was referenced in config but never created, and no staging deploy existed.
+
+The site is a small marketing/content property with a single maintainer plus occasional AI-assisted PRs. It needs a visible pre-production surface to verify Contentful content changes and syndicated-blog fetches, but does not justify the ceremony of release branches or feature flag infrastructure.
+
+## Decision
+
+Adopt a three-tier `feature → dev → main` branching strategy:
+
+- **`main`** — production. Deploys to the live site. No direct pushes; merges land only via PR from `dev`.
+- **`dev`** — staging. Integration branch that feeds the staging deploy and is verified before release.
+- **feature branches** — short-lived, cut from `dev`, named with conventional-commit-style prefixes (`feat/`, `fix/`, `chore/`, `docs/`).
+
+Hotfixes may branch from `main` directly but must be back-merged to `dev` immediately after release to keep the two aligned.
+
+CI (`pull_request` + `push`) triggers on both `main` and `dev`.
+
+## Alternatives considered
+
+- **Trunk-based development (single `main` + feature flags)** — rejected: no feature-flag infrastructure in place, and the marginal benefit for a small marketing site doesn't justify building one. Also removes the staging gate that's useful for verifying Contentful/syndicated content before production.
+- **GitHub Flow (`main` + short-lived feature branches, no staging)** — rejected: leaves no pre-production surface for verifying content changes. A marketing site with a CMS and external content sources benefits from a staging deploy that is not the live site.
+- **GitFlow (`master` + `develop` + `release/*` + `hotfix/*`)** — rejected: overkill for a continuously deployed marketing site. Release branches don't fit this cadence, and the mental overhead for a solo maintainer is not worth it.
+
+## Consequences
+
+- **Positive:** staging verification before production; a single integration branch; CI reliably runs on every PR; conventional-commit branch prefixes align with commit-message conventions.
+- **Negative:** two-step merge overhead (`feature → dev`, then `dev → main`) even for trivial changes; hotfix back-merge requires discipline to avoid drift between `main` and `dev`.
+- **Follow-ups:** a separate workstream is setting up branch-protection rules on `main` and `dev` (require PR, require CI pass, disallow direct push to `main`). Deploy configuration for the staging environment is also tracked separately.
+
+## Notes
+
+Recorded retroactively. The decision was made and documented in [PR #38](https://github.com/thomHayner/scaleforce-agency-landing/pull/38), which repointed CI triggers at `dev` and `main` and added a Branching workflow section to `README.md`. That PR also doubled as the first PR under the new flow (branched from `dev`, targets `dev`).

--- a/docs/adr/ADR-2026-04-21-multi-source-blog-architecture.md
+++ b/docs/adr/ADR-2026-04-21-multi-source-blog-architecture.md
@@ -1,0 +1,48 @@
+---
+id: ADR-2026-04-21-multi-source-blog-architecture
+title: Aggregate blog posts from three independent content sources
+status: accepted
+date: 2026-04-21
+deciders: [thom]
+tags: [blog, content, architecture]
+supersedes: []
+superseded_by: []
+related: []
+source: retroactive capture of commit d50abdb (feat(blog): add thomhayner.com as a third content source)
+---
+
+## Context
+
+The blog was originally a single source: local markdown via Astro content collections (`src/content/post/**`). Contentful was then added as a second source for case-study content that non-developers could edit in a CMS UI. A third source — syndicated posts from the author's personal blog at `thomHayner/thomHayner.com` — is now being added, loaded at build time via the public GitHub API and filtered to posts with `crossPostTo: ['scaleforce']` in their frontmatter.
+
+The design question was whether to keep these as three independent sources merged at read time, or to consolidate into one authoring surface. Each source has different authorship constraints: local markdown is developer-authored and lives with the code; Contentful is CMS-authored by non-developers; the personal blog is authored in markdown in a separate repo and its SEO canonical must remain pointed at the original domain.
+
+## Decision
+
+Keep three independent content sources and merge them at read time inside [`src/utils/blog.ts`](src/utils/blog.ts). Each source owns its own fetching and normalization:
+
+- **Local markdown** — Astro content collections in `src/content/post/**`.
+- **Contentful** — [`src/lib/contentful/contentful.ts`](src/lib/contentful/contentful.ts) for case studies.
+- **thomhayner.com** — [`src/lib/thomhayner/thomhayner.ts`](src/lib/thomhayner/thomhayner.ts) via the public GitHub API, opt-in per post via `crossPostTo` frontmatter.
+
+All three are normalized to a common `Post` shape so templates stay source-agnostic. Syndicated posts render with a canonical URL pointing back to `thomhayner.com` so SEO attribution stays with the original.
+
+## Alternatives considered
+
+- **Mirror all content into local markdown** — rejected: duplicates content, requires a sync pipeline from Contentful and from the personal blog, and creates a canonical-URL headache for syndicated posts. Authors would have to push to two places for every post.
+- **Mirror all content into Contentful** — rejected: the personal blog's authoring workflow is markdown-in-a-repo; forcing dual-author into Contentful breaks that workflow and couples the personal blog to this site's CMS choice.
+- **Drop content collections, keep only Contentful + thomhayner** — rejected: existing local posts would need migration, and the repo loses the ability to ship developer-authored content alongside code changes without a round-trip through the CMS. Also increases free-tier dependency on Contentful.
+- **Build at fetch time / ISR instead of static-at-build** — rejected: Astro's default SSG is sufficient for this volume; the GitHub API is fast enough at build time; no CMS webhook infrastructure exists for the syndicated source, so incremental revalidation has no real trigger.
+
+## Consequences
+
+- **Positive:** each content source evolves independently; the personal blog stays authored in its own repo; SEO attribution stays correct via canonical URLs; templates consume a single normalized shape; developer-authored posts can ship in the same PR as code changes.
+- **Negative:** the build now depends on GitHub API availability for the syndicated source; three fetch paths to maintain; no unified author entity — each source carries its own author metadata shape.
+- **Follow-ups:**
+  - Define a shared "author" content type so syndicated posts carry rich author metadata consistently across sources ([TODO.md](TODO.md)).
+  - Add GitHub API caching / ETag handling if build flakiness from the syndicated fetch becomes a problem.
+  - Decide how to handle thomhayner.com being unreachable at build time (fail the build vs. skip syndicated posts with a warning).
+
+## Notes
+
+Retroactive capture of the design introduced in commit `d50abdb`. The `crossPostTo: ['scaleforce']` opt-in is important: syndication is pull-based and explicit, so the author controls which personal posts appear here by editing frontmatter in the source repo.


### PR DESCRIPTION
## Context
Two architectural decisions are already in force in this repo but were never formally recorded: the `feature → dev → main` branching strategy (established in [PR #38](https://github.com/thomHayner/scaleforce-agency-landing/pull/38)) and the multi-source blog architecture (introduced in commit `d50abdb`). Without ADRs, the *why* behind these decisions lives only in PR descriptions and commit messages, where it decays and is hard to cite. Now that the ADR scaffold ([PR #39](https://github.com/thomHayner/scaleforce-agency-landing/pull/39)) gives us a canonical target directory and template, this PR backfills those two decisions so the record starts honest.

## Description
Adds two ADRs following the `docs/adr/TEMPLATE.md` convention, each grounded in the actual decision already landed. Neither invents rationale — every Context/Decision/Alternatives/Consequences section is drawn from the source PR description, commit message, or visible code. The bootstrap ADR (`ADR-2026-04-21-adopt-adr-and-docs-structure`) is delivered in PR #39, so this PR only adds the two retroactive captures.

## Changes in the codebase
- `docs/adr/ADR-2026-04-21-adopt-feature-dev-main-branching.md` — documents the three-tier branching flow, alternatives rejected (trunk-based, GitHub Flow, GitFlow), and known follow-ups (branch protection, staging deploy config).
- `docs/adr/ADR-2026-04-21-multi-source-blog-architecture.md` — documents the three independent content sources (local markdown, Contentful, thomhayner.com via GitHub API), the rationale for merging at read time rather than consolidating authoring, and follow-ups (unified author entity per `TODO.md`, GitHub API caching, build-time failure handling).

No application code is touched.

## Changes outside the codebase
None.

## Aditional information
- **Depends on [PR #39](https://github.com/thomHayner/scaleforce-agency-landing/pull/39)** (ADR scaffold). This branch is cut from `main` so the PR diff is clean (only the 2 retroactive ADRs). Functionally the ADRs are self-contained markdown and don't require the scaffold at build time, but reviewers should merge #39 first for coherence.
- Slugs follow the repo's date-based naming convention (`ADR-YYYY-MM-DD-<slug>.md`) rather than sequential numbers, per the rationale in the scaffold README (collision risk across parallel sessions/branches).
- Generated via Claude Code, but grounded against the actual PR #38 description and commit `d50abdb`; no fabricated history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)