### PR TITLE
chore(react): upgrade React 18 to 19 (Phase 5)

### DIFF
--- a/docs/adr/ADR-2026-04-21-react-18-to-19-upgrade.md
+++ b/docs/adr/ADR-2026-04-21-react-18-to-19-upgrade.md
@@ -1,0 +1,187 @@
+---
+id: ADR-2026-04-21-react-18-to-19-upgrade
+title: Bump React 18 to 19 alongside the rest of the Phase-5 dependency refresh
+status: accepted
+date: 2026-04-21
+deciders: [thomHayner, claude-opus-4-7]
+tags: [react, upgrade, dependencies, calendly]
+supersedes: []
+superseded_by: []
+related: [ADR-2026-04-21-astro-4-to-5-upgrade, ADR-2026-04-21-tailwind-3-to-4-migration, ADR-2026-04-21-node-ts-baseline-bump]
+source: claude-code-session-2026-04-21 react-18-to-19-upgrade
+---
+
+## Context
+
+Phase 5 of the multi-phase upgrade roadmap. Phases 0–4 have landed on
+`dev`: CI hardening, Astro 4 → 5 with the Content Layer, the Node 22+
+and TypeScript 5.9.3 baseline, and the Tailwind 3 → 4 migration to
+`@tailwindcss/vite` with CSS-first `@theme`. With the platform,
+framework, and styling layers refreshed, React 18.3.1 is now the
+oldest of the top-level runtimes still in `package.json`. React 19 GA
+shipped in December 2024, the 19.x line has been quiet and stable
+through 2025 and into 2026 (currently `19.2.5`), and the typings
+(`@types/react@19.2.14`, `@types/react-dom@19.2.3`) have long since
+caught up.
+
+The practical question was not "is React 19 ready" — it clearly is —
+but "what does this repo's React surface actually look like," because
+that determines how invasive the upgrade is.
+
+A full inventory of `src/`:
+
+- **Zero `.tsx` or `.jsx` files.** Every component in this template
+  is either `.astro` or plain TypeScript utility code.
+- **Zero `client:load` / `client:idle` / `client:visible` /
+  `client:only="react"` directives.** There are no hydrated React
+  islands shipping to the browser.
+- **No `@astrojs/react` integration** in `package.json` or
+  `astro.config.ts`. The Vite plugin chain has no JSX/React handling
+  beyond what Astro's default pipeline provides.
+- **One `import { InlineWidget } from "react-calendly"`**, in
+  `src/components/widgets/Calendly.astro`. That file is imported by
+  **nothing** — a repo-wide grep finds references to the string
+  "Calendly" only in the tailwind-migration ADR (as a QA checklist
+  item against the prod site) and in the `README.md`. The local
+  repo's page routes do not use it.
+
+So the React dependency tree is load-bearing in theory (satisfying
+`react-calendly`'s peers) but dead at the call-graph level — nothing
+renders React on either the server or the client. The `vite build`
+for the client bundle produces 13 modules, none of them React.
+
+`react-calendly`'s 4.4.0 release (May 2025) declares
+`"react": ">=16.8.0"` and `"react-dom": ">=16.8.0"` as peer
+dependencies, which accepts React 19 without complaint. That removed
+the one real risk flagged in the Phase-5 prompt.
+
+## Decision
+
+Bump `react` and `react-dom` from `^18.3.1` to `^19.2.5`, and bump
+`react-calendly` from `^4.3.1` to `^4.4.0`. Do **not** add
+`@types/react` / `@types/react-dom`, `@astrojs/react`, or any other
+React-adjacent dev tooling — this repo authors zero React code, so
+there is nothing for the types to service and no JSX for an
+integration to compile. `react-calendly` ships its own types,
+bundled; the only place they'd be referenced is inside the
+`Calendly.astro` frontmatter, and the Astro compiler's TypeScript
+layer resolves them transitively.
+
+Leave the dead `src/components/widgets/Calendly.astro` file in place.
+It is unused today, but the README and the Tailwind-migration ADR
+both treat the Calendly-embedded contact surface as part of the
+prod site's QA scope. A separate follow-up should reconcile that —
+either by wiring the widget into a real page (and at that point
+installing `@astrojs/react` and adding a `client:load` directive, so
+it actually hydrates) or by deleting the orphan file. Bundling that
+reconciliation into a dependency bump would conflate two decisions.
+
+## Alternatives considered
+
+- **Stay on React 18.3.1.** Rejected. React 18 is on long-term
+  maintenance; new work in the ecosystem targets 19. Staying on 18
+  compounds migration cost the same way staying on Tailwind 3 did.
+  There is no concrete blocker — `react-calendly` already accepts 19.
+- **Swap React for Preact via `@astrojs/preact`.** Rejected. The
+  repo has no React code to benefit from Preact's smaller runtime,
+  and `react-calendly` would need the `preact/compat` alias layer to
+  work at all. That's more moving parts than the problem warrants.
+- **Install `@astrojs/react` as part of this upgrade even though no
+  island uses it yet.** Rejected. The integration exists to compile
+  JSX and register a client runtime for `client:*` directives. With
+  zero JSX files and zero client directives, installing it would add
+  a dependency and a Vite plugin that does nothing. If the Calendly
+  widget (or anything else) is reactivated as a real island later,
+  the integration can be added at the same PR that wires it up — the
+  two changes belong together.
+- **Bump `@types/react` / `@types/react-dom` anyway, for
+  futureproofing.** Rejected for the same reason as the integration.
+  This repo authors no React. Adding types now is carrying code we
+  don't use; if a future PR introduces an island, that PR brings its
+  own type deps.
+- **Delete `Calendly.astro` as part of this upgrade.** Rejected as
+  out of scope. The file is dead but the widget is part of the
+  user-facing product surface per the README and the prior ADR's QA
+  notes — the right move is to either wire it up correctly or delete
+  it deliberately, in a PR that's about that question, not a React
+  version bump.
+
+## Consequences
+
+- **Positive:** The repo is current on React. When a future
+  contribution introduces an actual React island (most likely: the
+  Calendly embed becoming a real `client:load` component on a
+  contact page), they start from React 19 and can use ref-as-prop,
+  the improved hydration error messages, and the new
+  `useActionState` without carrying a React 18 baseline forward.
+  Dependabot won't nag about a 19.x upgrade. `npm install` stays
+  peer-conflict-free (no `--force`, no `--legacy-peer-deps`).
+- **Negative:** The `Calendly.astro` file has a latent correctness
+  issue that this upgrade does not fix: it imports a React component
+  but has no `client:*` directive and no React integration wired up.
+  If the file is ever imported by a page, the React runtime won't
+  hydrate it, and the widget will render as inert server markup.
+  That's a pre-existing problem — the upgrade neither creates nor
+  masks it — but it is now the most obvious loose thread in the
+  React layer, and the next person to touch Calendly should treat
+  it as the first thing to fix.
+- **Contributor onboarding:** The 19.x patterns worth knowing if a
+  future island lands here are ref-as-prop on function components
+  (no more `forwardRef` boilerplate), `useActionState` replacing
+  `useFormState`, and the legacy-context / string-refs / class
+  `defaultProps`-on-function-components removals. None of those
+  apply to the current codebase — flagged here so future PRs don't
+  regress into 18-era patterns.
+- **Follow-ups:**
+  - Decide the fate of `src/components/widgets/Calendly.astro` —
+    either wire it into a real contact page (adding `@astrojs/react`,
+    `@types/react`, `@types/react-dom`, and a `client:load`
+    directive in the same PR) or delete it.
+  - Phase 6 on the roadmap: rename the package away from
+    `@onwidget/astrowind`.
+  - If any React island lands later, revisit whether
+    `@astrojs/preact` is worth considering at that point — the
+    decision is less clear-cut for islands than for a zero-React
+    codebase.
+
+## Notes
+
+- **Breaking-change sweep:** grepped `src/` for `forwardRef`,
+  `propTypes`, `defaultProps`, `contextTypes`, `getChildContext`,
+  `ReactDOM.render`, and `useFormState`. Zero matches. No code
+  changes were required for React 19 semantic differences, because
+  no first-party code exercises any of those APIs.
+- **Dependency versions landed on:**
+  - `react` `^19.2.5` (from `^18.3.1`)
+  - `react-dom` `^19.2.5` (from `^18.3.1`)
+  - `react-calendly` `^4.4.0` (from `^4.3.1`)
+- **`react-calendly` compatibility verdict:** 4.4.0 (May 2025
+  release) declares `"react": ">=16.8.0"` and
+  `"react-dom": ">=16.8.0"` as peer deps. React 19.2.5 installs
+  cleanly against that range with no `--force` or
+  `--legacy-peer-deps`. No known runtime issues in the release notes
+  touching 19-specific behavior (hydration, `useId`, etc.).
+- **Not bumped:** `@types/react`, `@types/react-dom`, and
+  `@astrojs/react` were considered and deliberately not added — see
+  Alternatives. If any of them show up in a future PR, that PR
+  should also add JSX code that exercises them.
+- **CI:** `npm install` (no flags) succeeded. `npm run check:astro`
+  passed (0 errors / 0 warnings / 0 hints across 95 files).
+  `npm run check:eslint` passed. `npm run build` proceeded past the
+  React/Vite stages cleanly and failed at the same Contentful
+  `accessToken` secret gate documented in the Astro 5 and Tailwind
+  ADRs — CI and Vercel have the real `CONTENTFUL_*` secrets.
+  `npm run dev` booted in ~400 ms with no React or hydration
+  warnings in the console. The client bundle built by the Vite
+  stage contains 13 modules, none of them React — confirming that
+  Calendly.astro's `react-calendly` import is tree-shaken out.
+- **Manual QA scope for the merge gate (HS-6):** the user should
+  walk any page that currently embeds the Calendly widget on the
+  deployed site and confirm it still loads, but given that this
+  repo's `Calendly.astro` is an orphan, the practical QA here is a
+  general island smoke test (there are none), plus a console check
+  during production navigation after Vercel redeploys with the real
+  secrets. No React 19-specific UI regressions are expected because
+  no React runs in the browser on this site today.
+- No env vars, secrets, or external-service touchpoints were added
+  or changed as part of this upgrade.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
         "gray-matter": "^4.0.3",
         "limax": "4.1.0",
         "lodash.merge": "^4.6.2",
-        "react": "^18.3.1",
-        "react-calendly": "^4.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.5",
+        "react-calendly": "^4.4.0",
+        "react-dom": "^19.2.5",
         "remark": "^15.0.1",
         "remark-html": "^16.0.1",
         "unpic": "^3.18.0"
@@ -6980,10 +6980,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "license": "MIT",
@@ -7383,16 +7379,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lower-case": {
@@ -9052,17 +9038,18 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-calendly": {
-      "version": "4.3.1",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-calendly/-/react-calendly-4.4.0.tgz",
+      "integrity": "sha512-kMd8fEby0plL5aCebhjq9aesOJ6YWcmR3Pjs3bufncykrp7b6TryaCnWGoq4xZc/oipyudAVCIRgPVUjUEr8nQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8",
@@ -9074,14 +9061,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.5"
       }
     },
     "node_modules/reading-time": {
@@ -9525,11 +9513,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "gray-matter": "^4.0.3",
     "limax": "4.1.0",
     "lodash.merge": "^4.6.2",
-    "react": "^18.3.1",
-    "react-calendly": "^4.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.5",
+    "react-calendly": "^4.4.0",
+    "react-dom": "^19.2.5",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
     "unpic": "^3.18.0"


### PR DESCRIPTION
## Summary

- Bump `react` and `react-dom` from `^18.3.1` to `^19.2.5`.
- Bump `react-calendly` from `^4.3.1` to `^4.4.0`.
- Record the upgrade decision in `docs/adr/ADR-2026-04-21-react-18-to-19-upgrade.md`.

This is Phase 5 of the multi-phase upgrade roadmap and is a pure dependency refresh — no first-party code changes, because this repo authors no React code today.

## React usage inventory

Full grep of `src/`:

- `.tsx` / `.jsx` files: **0**
- `import ... from \"react\"` / `\"react-dom\"`: **0**
- `client:load` / `client:idle` / `client:visible` / `client:only=\"react\"` directives: **0**
- `react-calendly` imports: **1** — `src/components/widgets/Calendly.astro` (`import { InlineWidget } from \"react-calendly\";`)
- Repo-wide references to `Calendly.astro`: **none in `src/`**. The only string matches on \"Calendly\" outside that file are in `README.md` and the Tailwind-migration ADR, both of which reference the prod site's contact surface, not the local component. The file is effectively dead.
- `@astrojs/react` in `package.json`: **not present**. No React integration is wired into `astro.config.ts`, and `@astrojs/react` was deliberately not added here — see ADR for reasoning.
- React 19 breaking-change sweep (`forwardRef`, `propTypes`, `defaultProps`, `contextTypes`, `getChildContext`, `ReactDOM.render`, `useFormState`): **0 matches**.

## react-calendly compatibility verdict

Landed on `react-calendly@^4.4.0` (latest, published May 2025). Peer declaration:

\`\`\`
\"react\": \">=16.8.0\"
\"react-dom\": \">=16.8.0\"
\`\`\`

React 19.2.5 satisfies this range cleanly. `npm install` completes with no peer conflicts, no `--force`, and no `--legacy-peer-deps`. No 19-specific runtime caveats surfaced in the release notes.

## Breaking-change adaptations applied

**None.** The breaking-change sweep found zero occurrences of any deprecated React 19 API in the repo, because there is no first-party React code.

## Test plan

- [x] `npm install` — succeeds without `--force`. No peer conflicts.
- [x] `npm run check:astro` — passes (0 errors / 0 warnings / 0 hints across 95 files).
- [x] `npm run check:eslint` — passes.
- [x] `npm run build` — progresses past the Vite/React stages; the client bundle builds 13 modules and none of them are React (confirming Calendly.astro is tree-shaken out). Fails at the same Contentful `accessToken` gate documented in the Astro 5 and Tailwind 4 ADRs — CI and Vercel have the real `CONTENTFUL_*` secrets, so trust CI here.
- [x] `npm run dev` — boots in ~400 ms on `http://localhost:4321/`, no React / hydration warnings in the console.
- [x] **Manual QA required (HS-6):** walk the deployed Calendly widget surface on the prod site and confirm the scheduler still loads and the inline widget still renders after Vercel redeploys. Also a general smoke test of any ClientRouter navigation — no islands are expected, but verify the console stays clean. **Caveat:** `src/components/widgets/Calendly.astro` is not wired into any page in this repo, so the only live Calendly surface is whatever is deployed today via the CMS/content layer; this upgrade does not change that behavior.

## Notes / follow-ups

- `Calendly.astro` has a latent correctness issue this PR does not fix: it imports a React component but the repo has no `@astrojs/react` integration and the file uses no `client:*` directive, so if it were ever rendered into a page the React runtime would not hydrate it. See the ADR's Alternatives and Consequences sections — the right fix is either to wire it into a real contact page (installing `@astrojs/react`, `@types/react`, `@types/react-dom`, and adding `client:load` in the same PR) or to delete the orphan file. That decision belongs in its own PR.
- Peer conflicts or version surprises: none.
- `@astrojs/react` was not present before and was not added here — deliberate; see ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)