### PR TITLE
chore: detach from AstroWind template (Phase 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,276 +1,82 @@
-# ScaleForce.agency Landing and Lead Generation Site
-Built on top of the AstroWind template from [onWidget](https://onwidget.com).  **AstroWind** is a free and open-source template to make your website using **[Astro 4.0](https://astro.build/) + [Tailwind CSS](https://tailwindcss.com/)**.
+# Scaleforce Agency Landing
+
+Marketing and lead-generation site for [ScaleForce.agency](https://ScaleForce.agency), an AI / automations / operations agency. Built with Astro 5 and Tailwind 4, with blog content aggregated from local markdown, Contentful, and the author's personal blog at `thomhayner.com`.
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/6827720e-01b1-4d10-a380-6e58995a83d3/deploy-status)](https://app.netlify.com/sites/scaleforce/deploys)
 
-<br>
+## Quick start
 
-<details open>
-<summary>Table of Contents</summary>
+```bash
+npm install
+npm run dev      # local dev server
+npm run build    # production build to ./dist/
+npm run preview  # preview the production build locally
+```
 
-- [Customizations, Packages, Integrations and Extensions](#customizations-packages-integrations-and-extensions)
-- [DevOps](#devops)
-- [AstroWind Template Docs](#astrowind-template-docs)
-  - [Getting started](#getting-started)
-    - [Project structure](#project-structure)
-    - [Commands](#commands)
-    - [Configuration](#configuration)
-    - [Customize Design](#customize-design)
-  - [Acknowledgements](#acknowledgements)
-  - [License](#license)
+Dev server defaults to `http://localhost:4321`.
 
-</details>
+## Required environment variables
 
-<br>
+The build pulls content from external sources and will fail without these set (see the deploy environment in Netlify, or a local `.env` for development):
 
-## Customizations, Packages, Integrations and Extensions
+| Variable | Purpose |
+| --- | --- |
+| `CONTENTFUL_SPACE_ID` | Contentful space for CMS-authored blog posts and case studies. |
+| `CONTENTFUL_DELIVERY_TOKEN` | Contentful Content Delivery API token (published content). |
+| `CONTENTFUL_PREVIEW_TOKEN` | Contentful Preview API token (draft content in preview mode). |
+| `AIRTABLE_API_KEY` | Airtable API key (legacy integration; see `src/lib/astro-airtable/`). |
+| `AIRTABLE_BASE_ID` | Airtable base id used by the legacy integration. |
 
-Astro is a great base to start building static websites from and AstroWind is even better.  It has a library of prebuilt components to use when designing your site and it can be customized as much as needed.
+The Airtable integration is not currently wired into the default build but the env vars are still referenced by the legacy code in the repo.
 
-- [Google Tags Manager](https://tagmanager.google.com/): This site uses GTM for advanced analytics and conversion tracking.  AstroWind has support for basic [Google Analytics (GA4)](https://analytics.google.com/) but not for GTM.  I build a simple custom integration for GTM that matches the pattern used by AstroWind for GA4.
+## Scripts
 
-- [Contentful & Astro Integration](https://docs.astro.build/en/guides/cms/contentful/): This site uses the [Contentful SDK](https://github.com/contentful/contentful.js) integration from [Contentful](https://www.contentful.com) to provides image hosting and blog posts.
+| Command | What it does |
+| --- | --- |
+| `npm run dev` | Start the Astro dev server. |
+| `npm run build` | Produce a production build in `./dist/`. |
+| `npm run preview` | Serve the built `./dist/` locally. |
+| `npm run check` | Run `check:astro` then `check:eslint`. |
+| `npm run check:astro` | Astro type/diagnostic check (`astro check`). |
+| `npm run check:eslint` | ESLint across the repo. |
+| `npm run fix` | `eslint --fix` across the repo. |
+| `npm run astro ...` | Pass-through to the Astro CLI. |
 
-- [npm react-calendly](https://www.npmjs.com/package/react-calendly): This site uses an integration with Calendly to embed their platform's calendar and scheduling components.
+## Tech stack
 
-- [airtable](https://www.npmjs.com/package/airtable): Originally I had planned to use [Airtable](https://www.airtable.com/) as a custom CMS.  There is no Airtable & Astro integration avaialble so I built a custom integration with a REST API (the file is still in this repo, located [here](https://github.com/ScaleForceAgency/scaleforce-agency-landing/blob/main/src/integrations/astro-airtable/astro-airtable.ts)) to connect to Airtable, as well as a [Make.com](https://www.Make.com) webhook automation to trigger a Netlify "Build & Deploy" sequence (it used a button in one of the Airtable columns that would trigger the webhook and tell Netlify to build and deploy to production).  Airtable uses dynamic links for imagesthat change every 1-2 days, so it does not suport image hosting for static sites.  That meant I would need to use Contentful for images, and I decided to remove Airtable altogether from this project.  I left the legacy code there as an example of how to integrate Aitable into Astro as a custom CMS.
+- [Astro 5](https://astro.build/) — static-site generation, content collections, image pipeline.
+- [Tailwind CSS 4](https://tailwindcss.com/) — CSS-first theme via `@tailwindcss/vite`.
+- [TypeScript 5.9](https://www.typescriptlang.org/) — strict mode.
+- [React 19](https://react.dev/) — used for Calendly embeds and isolated interactive components.
+- [Node 22+](https://nodejs.org/) — required runtime for local dev and CI.
+- [Contentful](https://www.contentful.com/) — CMS for blog / case-study content.
+- [Netlify](https://www.netlify.com/) — production hosting.
 
-<br>
+## Branching workflow
 
-## DevOps
+`feature → dev → main`:
 
-### Branching workflow
-
-This repo uses a `feature → dev → main` flow:
-
-- **`main`** — production. Deploys to the live site. Never push directly; merges land only via PR from `dev`.
-- **`dev`** — staging. Integration branch used to verify changes on the staging deploy before release.
-- **feature branches** — short-lived branches (e.g. `feat/...`, `fix/...`, `chore/...`) cut from `dev`.
+- **`main`** — production. Deploys to the live site. PRs only, from `dev`.
+- **`dev`** — staging. Integration branch.
+- **feature branches** — short-lived (`feat/...`, `fix/...`, `chore/...`) cut from `dev`.
 
 Standard flow:
 
-1. Branch from `dev`: `git checkout dev && git pull && git checkout -b feat/my-change`
+1. `git checkout dev && git pull && git checkout -b feat/my-change`
 2. Open a PR targeting `dev`. CI must pass.
 3. Once merged to `dev`, verify on the staging deploy.
 4. When a release is ready, open a PR from `dev` → `main`. Merging triggers the production deploy.
 
 Hotfixes may branch from `main` directly, but must be back-merged to `dev` immediately after release.
 
-### Netlify
+## Architectural decisions
 
-There are currently two Netlify "Build & Deploy" triggers.  
+Non-trivial design choices are recorded as ADRs under [`docs/adr/`](docs/adr/README.md). Start there for the *why* behind the phased Astro / Tailwind / React upgrades, the multi-source blog architecture, the CI layout, and the detach from the AstroWind template.
 
-The first trigger is a code push to the ```main``` branch of the [GitHub repository](https://github.com/scaleforce-agency/scaleforce-agency-landing) for this website (which is probably where you are reading this README file right now).  This trigger handles any approved pull requests and code updates.
+## Credits
 
-The second trigger is the change in status to ```published``` for blog posts within my Contentful CMS.  That trigger handles content changes and blog updates.
+This codebase started from the [AstroWind](https://github.com/onwidget/astrowind) template (MIT-licensed, © onWidget) and has since diverged substantially — it now runs Astro 5, Tailwind 4, React 19, and Node 22+, with a bespoke multi-source blog pipeline, custom CI, and an ADR-based decision log. Upstream AstroWind is no longer tracked; future upgrades are owned directly here. See [`docs/adr/ADR-2026-04-21-detach-from-astrowind-template.md`](docs/adr/ADR-2026-04-21-detach-from-astrowind-template.md) for the decision record.
 
-### GitHub
+## License
 
-To update this repo with upstream changes made to the original AstroWind Template, use the following commands:
-
-``` git remote add template https://github.com/onwidget/astrowind.git```
-
-``` git fetch --all ```
-
-``` git merge template/main --allow-unrelated-histories ```
-
-More info here [https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories).
-
-<br>
-
-## AstroWind Template Docs
-
-The rest of this document contains the original AstroWind template README, credit to the original template developer [onWidget](https://onwidget.com), and the original template [LICENSE](./LICENSE.md).
-
-<br>
-
-### Getting started
-
-**AstroWind** tries to give you quick access to creating a website using [Astro 4.0](https://astro.build/) + [Tailwind CSS](https://tailwindcss.com/). It's a free theme which focuses on simplicity, good practices and high performance.
-
-Very little vanilla javascript is used only to provide basic functionality so that each developer decides which framework (React, Vue, Svelte, Solid JS...) to use and how to approach their goals.
-
-In this version the template supports all the options in the `output` configuration, `static`, `hybrid` and `server`, but the blog only works with `prerender = true`. We are working on the next version and aim to make it fully compatible with SSR.
-
-#### Project structure
-
-Inside **AstroWind** template, you'll see the following folders and files:
-
-```
-/
-├── public/
-│   ├── _headers
-│   └── robots.txt
-├── src/
-│   ├── assets/
-│   │   ├── favicons/
-│   │   ├── images/
-│   │   └── styles/
-│   │       └── tailwind.css
-│   ├── components/
-│   │   ├── blog/
-│   │   ├── common/
-│   │   ├── ui/
-│   │   ├── widgets/
-│   │   │   ├── Header.astro
-│   │   │   └── ...
-│   │   ├── CustomStyles.astro
-│   │   ├── Favicons.astro
-│   │   └── Logo.astro
-│   ├── content/
-│   │   ├── post/
-│   │   │   ├── post-slug-1.md
-│   │   │   ├── post-slug-2.mdx
-│   │   │   └── ...
-│   │   └-- config.ts
-│   ├── layouts/
-│   │   ├── Layout.astro
-│   │   ├── MarkdownLayout.astro
-│   │   └── PageLayout.astro
-│   ├── pages/
-│   │   ├── [...blog]/
-│   │   │   ├── [category]/
-│   │   │   ├── [tag]/
-│   │   │   ├── [...page].astro
-│   │   │   └── index.astro
-│   │   ├── index.astro
-│   │   ├── 404.astro
-│   │   ├-- rss.xml.ts
-│   │   └── ...
-│   ├── utils/
-│   ├── config.yaml
-│   └── navigation.js
-├── package.json
-├── astro.config.mjs
-└── ...
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory if they do not require any transformation or in the `assets/` directory if they are imported directly.
-
-[![Edit AstroWind on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/onwidget/astrowind/tree/main) [![Open in Gitpod](https://svgshare.com/i/xdi.svg)](https://gitpod.io/?on=gitpod#https://github.com/onwidget/astrowind) [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/onwidget/astrowind)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file `README.md`. Update `src/config.yaml` and contents. Have fun!
-
-<br>
-
-#### Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command             | Action                                             |
-| :------------------ | :------------------------------------------------- |
-| `npm install`       | Installs dependencies                              |
-| `npm run dev`       | Starts local dev server at `localhost:3000`        |
-| `npm run build`     | Build your production site to `./dist/`            |
-| `npm run preview`   | Preview your build locally, before deploying       |
-| `npm run check`     | Check your project for errors                      |
-| `npm run fix`       | Run Eslint with `--fix` to auto-fix lint issues    |
-| `npm run astro ...` | Run CLI commands like `astro add`, `astro preview` |
-
-<br>
-
-#### Configuration
-
-Basic configuration file: `./src/config.yaml`
-
-```yaml
-site:
-  name: 'Example'
-  site: 'https://example.com'
-  base: '/' # Change this if you need to deploy to Github Pages, for example
-  trailingSlash: false # Generate permalinks with or without "/" at the end
-
-  googleSiteVerificationId: false # Or some value,
-
-# Default SEO metadata
-metadata:
-  title:
-    default: 'Example'
-    template: '%s — Example'
-  description: 'This is the default meta description of Example website'
-  robots:
-    index: true
-    follow: true
-  openGraph:
-    site_name: 'Example'
-    images:
-      - url: '~/assets/images/default.png'
-        width: 1200
-        height: 628
-    type: website
-  twitter:
-    handle: '@twitter_user'
-    site: '@twitter_user'
-    cardType: summary_large_image
-
-i18n:
-  language: en
-  textDirection: ltr
-
-apps:
-  blog:
-    isEnabled: true # If the blog will be enabled
-    postsPerPage: 6 # Number of posts per page
-
-    post:
-      isEnabled: true
-      permalink: '/blog/%slug%' # Variables: %slug%, %year%, %month%, %day%, %hour%, %minute%, %second%, %category%
-      robots:
-        index: true
-
-    list:
-      isEnabled: true
-      pathname: 'blog' # Blog main path, you can change this to "articles" (/articles)
-      robots:
-        index: true
-
-    category:
-      isEnabled: true
-      pathname: 'category' # Category main path /category/some-category, you can change this to "group" (/group/some-category)
-      robots:
-        index: true
-
-    tag:
-      isEnabled: true
-      pathname: 'tag' # Tag main path /tag/some-tag, you can change this to "topics" (/topics/some-category)
-      robots:
-        index: false
-
-    isRelatedPostsEnabled: true # If a widget with related posts is to be displayed below each post
-    relatedPostsCount: 4 # Number of related posts to display
-
-analytics:
-  vendors:
-    googleAnalytics:
-      id: null # or "G-XXXXXXXXXX"
-    googleTags Manager:
-      id: null # or "GTM-XXXXXXXX"
-
-ui:
-  theme: 'system' # Values: "system" | "light" | "dark" | "light:only" | "dark:only"
-```
-
-<br>
-
-#### Customize Design
-
-To customize Font families, Colors or more Elements refer to the following files:
-
-- `src/components/CustomStyles.astro`
-- `src/assets/styles/tailwind.css`
-
-<br>
-
-### Acknowledgements
-
-Initially created by [onWidget](https://onwidget.com) and maintained by a community of [contributors](https://github.com/onwidget/astrowind/graphs/contributors).
-
-<br>
-
-### License
-
-**AstroWind** is licensed under the MIT license — see the [LICENSE](./LICENSE.md) file for details.
+MIT — see [`LICENSE.md`](./LICENSE.md).

--- a/docs/adr/ADR-2026-04-21-detach-from-astrowind-template.md
+++ b/docs/adr/ADR-2026-04-21-detach-from-astrowind-template.md
@@ -1,0 +1,72 @@
+---
+id: ADR-2026-04-21-detach-from-astrowind-template
+title: Detach from the AstroWind template and own the codebase directly
+status: accepted
+date: 2026-04-21
+deciders: [thom]
+tags: [project, governance, branding, tooling]
+supersedes: []
+superseded_by: []
+related:
+  - ADR-2026-04-21-astro-4-to-5-upgrade
+  - ADR-2026-04-21-tailwind-3-to-4-migration
+  - ADR-2026-04-21-react-18-to-19-upgrade
+  - ADR-2026-04-21-ci-hardening-split-and-eslint-env-override
+  - ADR-2026-04-21-multi-source-blog-architecture
+source: claude-code-session-2026-04-21 phase-6-detach-from-astrowind
+---
+
+## Context
+
+This repo started life as a fork of the [AstroWind](https://github.com/onwidget/astrowind) template (© onWidget, MIT). Several things have changed since then:
+
+- **Upstream is semi-dormant.** Last meaningful commit to `onwidget/astrowind` was August 2025; last release was December 2024. The original maintainer publicly handed the project off. Tracking upstream is no longer a live option — there's effectively nothing to track.
+- **This codebase has diverged substantially.** Over the recent phased upgrade series it moved to Astro 5 (ADR-2026-04-21-astro-4-to-5-upgrade), Tailwind 4 with CSS-first `@theme` (ADR-2026-04-21-tailwind-3-to-4-migration), React 19 (ADR-2026-04-21-react-18-to-19-upgrade), Node 22+ as the required runtime, a bespoke multi-source blog pipeline (ADR-2026-04-21-multi-source-blog-architecture), a custom CI layout (ADR-2026-04-21-ci-hardening-split-and-eslint-env-override), and an ADR-based decision log. The "template" framing no longer describes what the repo is.
+- **Template-lock-in is less valuable in an LLM-assisted workflow.** The original benefit of staying close to a template was "easy to take upstream updates." With most work now driven by focused, ADR-tracked edits, that benefit is smaller than the cost of retaining template-flavored metadata, README, and branding that misrepresents the project.
+- **Package identity is still template-flavored.** `package.json` still says `@onwidget/astrowind` at version `1.0.0-beta.46` (AstroWind's upstream version string). The README is mostly the upstream AstroWind README with a thin Scaleforce preamble. Both are misleading to anyone (human or LLM) reading the repo.
+
+Phase 6 of the phased upgrade is the point to formalize detaching from the template identity.
+
+## Decision
+
+Detach from the AstroWind template. Specifically:
+
+- **Rename the npm package** `@onwidget/astrowind` → `scaleforce-agency-landing` (matches the GitHub repo name, unscoped).
+- **Reset the version** `1.0.0-beta.46` → `0.1.0`. This project owns its versioning from here; the old version string was AstroWind's, not ours.
+- **Rewrite the `description`** to "Scaleforce Agency landing site — Astro 5 + Tailwind 4." — accurate and short.
+- **Keep `private: true`** — this hard-blocks npm publishing and stays in force. The site is not a reusable package.
+- **Rewrite `README.md`** to describe this project on its own terms: quick-start, env vars, scripts, tech stack, branching workflow, pointer to `docs/adr/`, and a short, honest Credits section acknowledging AstroWind as the original template source without advertising the template.
+- **Sweep lingering `@onwidget` / `AstroWind` / `astrowind` references** outside of the `astrowind:config` virtual module, and update or remove template-flavored content that no longer describes this project.
+
+Upstream is no longer tracked. Future Astro / Tailwind / dependency upgrades are owned directly by this project's phased upgrade process and recorded as ADRs.
+
+## Alternatives considered
+
+- **Keep the forked relationship and the template identity.** Rejected. Upstream is semi-dormant, divergence is already large, and the template-flavored README/metadata actively misrepresents the project to readers (and LLMs). The cost of staying close to a dormant template is high; the benefit (cheap upstream sync) no longer exists.
+- **Rename the `astrowind:config` virtual module and all ~15 import sites in this PR.** Rejected for this phase. The virtual module is set up by `vendor/integration/index.ts` and exported types in `vendor/integration/types.d.ts`; renaming it touches roughly 50 files of churn for zero functional gain. Recorded as a chip-sized follow-up.
+- **Publish to npm under the new name.** Rejected. This is a site, not a reusable package. `private: true` stays, which hard-blocks accidental publish.
+- **Rebrand visual identity (favicon, logo, OG image) in this PR.** Rejected for this phase. Visual identity is Phase 7 redesign territory. Scope-matching this PR to *package, metadata, docs* keeps the review tight and leaves visual decisions for the redesign.
+- **Retain the old README structure and just edit the AstroWind mentions.** Rejected. The existing README is largely template documentation (Getting Started, project-structure tree, CodeSandbox / Gitpod / StackBlitz badges, Seasoned astronaut line, configuration yaml dump). Patching names leaves the project still reading as a template wrapper. Rewriting is the right scope.
+
+## Consequences
+
+- **Positive:**
+  - `package.json` identity matches reality. No more confusion about whether this is the AstroWind template or a project built on it.
+  - Contributors (and future LLMs reading the repo) have a README that describes what this *is* rather than instructions for using a template to build something else.
+  - Versioning is owned: `0.1.0` onward, free to evolve via normal semver when/if this becomes release-tagged, not constrained by the upstream's `1.0.0-beta.*` lineage.
+  - Template credit is preserved honestly via the README Credits section and the MIT copyright line in `LICENSE.md` — attribution without advertising.
+- **Negative:**
+  - No more implicit option of `git merge template/main` to pick up upstream changes. The previous README had instructions for this; they're now removed. Given upstream is dormant, this is effectively a loss of nothing, but it's formally a loss of optionality.
+  - Contributors accustomed to AstroWind documentation patterns will no longer find them in this repo's README. Mitigated by the Credits link to the upstream repo.
+- **Follow-ups:**
+  - **Rename the `astrowind:config` virtual module** to something project-owned (e.g. `scaleforce:config` or `~/config`). Touches `vendor/integration/index.ts`, `vendor/integration/types.d.ts`, and ~15 `astrowind:config` import sites. Chip-sized, non-urgent, deferred.
+  - **Rename internal log channel names and Vite plugin names** inside `vendor/integration/index.ts` (`astrowind-integration`, `vite-plugin-astrowind-config`, `logger.fork('astrowind')`). Done in the same pass as the virtual-module rename above.
+  - **Rename the `.vscode/astrowind/` folder and its `config-schema.json`** plus the pointer in `.vscode/settings.json`. IDE-local, non-urgent, bundle with the virtual-module rename.
+  - **`src/pages/terms.md` and `src/pages/privacy.md`** contain template demo legal text ("AstroWind LLC, 1 Cupertino, CA 95014", `astrowind.vercel.app`). This is content, not code; needs real legal copy from the user. Flagged in the detach PR body but **not fabricated** here.
+  - **Visual rebrand** (favicon, logo, OG image, any AstroWind-styled assets under `public/` or `src/assets/`) — scoped to Phase 7 redesign, not this phase.
+
+## Notes
+
+- `astro.config.ts` was checked for template-origin `site:` URL or analytics config. The site URL lives in `src/config.yaml` (`https://ScaleForce.agency`), which is already Scaleforce-branded. `astro.config.ts` itself contains only the `astrowind` integration import (retained per the deferred virtual-module rename) and no template-origin URLs or analytics IDs.
+- `LICENSE.md` retains the original "Copyright (c) 2023 onWidget" line. The MIT license permits continued use with the original copyright notice preserved; removing it would be wrong, and adding a dual Scaleforce copyright is a decision for the user rather than this detach pass.
+- The name `scaleforce-agency-landing` matches the GitHub repo and is unscoped. Combined with `private: true`, this makes the npm namespace a non-issue: no publishing is possible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@onwidget/astrowind",
-  "version": "1.0.0-beta.46",
+  "name": "scaleforce-agency-landing",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@onwidget/astrowind",
-      "version": "1.0.0-beta.46",
+      "name": "scaleforce-agency-landing",
+      "version": "0.1.0",
       "dependencies": {
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@onwidget/astrowind",
-  "version": "1.0.0-beta.46",
-  "description": "AstroWind: A free template using Astro 5 and Tailwind CSS. Astro starter theme.",
+  "name": "scaleforce-agency-landing",
+  "version": "0.1.0",
+  "description": "Scaleforce Agency landing site — Astro 5 + Tailwind 4.",
   "type": "module",
   "private": true,
   "engines": {

--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -11,7 +11,8 @@
 
 /* ---------------------------------------------------------------------------
  * Theme tokens — port of the old `tailwind.config.js` `theme.extend` block.
- * Values are wired to the AstroWind `--aw-*` CSS variables that
+ * Values are wired to the `--aw-*` CSS variables (originally named by the
+ * AstroWind template this project derived from) that
  * `src/components/CustomStyles.astro` sets on :root / .dark.
  * ------------------------------------------------------------------------- */
 @theme {

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,4 +1,10 @@
-This folder will become an integration for **AstroWind**.
+Vendored Astro integration originally derived from the AstroWind template.
 
-We are working to allow updates to template instances.
-These are changes on the way to new **AstroWind v2**
+Provides the `astrowind:config` virtual module (resolved by the Vite plugin
+in `./integration/index.ts`) that exposes parsed `src/config.yaml` values —
+`SITE`, `I18N`, `METADATA`, `APP_BLOG`, `UI`, `ANALYTICS` — to components
+via typed imports.
+
+The virtual-module name is retained for now to avoid churning ~50 import
+sites across the codebase; renaming it is tracked as a follow-up in
+`docs/adr/ADR-2026-04-21-detach-from-astrowind-template.md`.


### PR DESCRIPTION
## Summary

- **`package.json` rename.** `@onwidget/astrowind` → `scaleforce-agency-landing` (matches the GitHub repo name, unscoped). `private: true` stays.
- **Version reset.** `1.0.0-beta.46` (AstroWind's upstream version string) → `0.1.0`. This project owns versioning from here.
- **Description rewrite.** `"Scaleforce Agency landing site — Astro 5 + Tailwind 4."`
- **`README.md` rewritten.** Describes this project on its own terms: quick-start, env vars (Contentful / Airtable), scripts reference, tech stack (Astro 5 / Tailwind 4 / TS 5.9 / React 19 / Node 22+), branching workflow, pointer to `docs/adr/`, honest short Credits section linking back to AstroWind. Drops the template-flavored Getting Started / project-structure tree / CodeSandbox-Gitpod-StackBlitz badges / configuration yaml dump / upstream-sync instructions.
- **Lingering template references cleaned up** in `vendor/README.md` (rewritten to describe what the vendored integration does here) and `src/assets/styles/tailwind.css` (softened comment). Full disposition below.
- **ADR.** `docs/adr/ADR-2026-04-21-detach-from-astrowind-template.md` captures context, decision, alternatives, consequences, follow-ups.

## Why

Upstream AstroWind is semi-dormant (last meaningful commit Aug 2025, last release Dec 2024, original maintainer handed off). This repo has diverged substantially over the phased upgrade series — Astro 5, Tailwind 4, React 19, Node 22+, custom multi-source blog pipeline, custom CI, ADR log. The old `@onwidget/astrowind` package identity and the template-wrapper README no longer describe what this project is, and the implicit "we might pick up upstream updates" framing is fiction given upstream state. Phase 6 formalizes the detach: own the codebase, credit AstroWind honestly in the README, stop pretending to track upstream.

## What's NOT in this PR

- **`astrowind:config` virtual module rename.** Deferred. The virtual module is set up in `vendor/integration/index.ts` and consumed at ~15 import sites across `src/`. Renaming is ~50 files of churn for zero functional gain; tracked as a chip-sized follow-up in the detach ADR.
- **Visual identity.** Favicon, logo, OG images, any AstroWind-styled visual assets under `public/` and `src/assets/` are untouched. Scoped to Phase 7 redesign.
- **`src/pages/terms.md` and `src/pages/privacy.md`.** These contain template demo legal text ("AstroWind LLC, 1 Cupertino, CA 95014", `astrowind.vercel.app`). Content, not code — needs real legal copy from you rather than a fabricated replacement. **Action item for you.**
- **`LICENSE.md` copyright line.** MIT permits continued use with the original copyright notice; stripping attribution would be wrong. If you want dual-copyright ("© 2023 onWidget, © 2026 Scaleforce Agency"), that's a separate decision for you to make.
- **npm publishing.** `private: true` stays. The site is not a reusable package.

## Grep findings and disposition

Swept for `@onwidget`, `astrowind`, `AstroWind`, `onwidget` (case-insensitive):

**Updated:**
- `package.json` — name, version, description rewritten.
- `README.md` — full rewrite (credits preserved, template advertising removed).
- `vendor/README.md` — rewritten to describe the integration as it is now, not as "on the way to AstroWind v2."
- `src/assets/styles/tailwind.css` — "AstroWind `--aw-*` CSS variables" comment softened to note the derivation without actively branding.

**Left alone (deferred — see ADR follow-ups):**
- `vendor/integration/index.ts` — integration name `astrowind-integration`, Vite plugin name `vite-plugin-astrowind-config`, log channel `logger.fork('astrowind')`, virtual module id `astrowind:config`, log messages prefixed `Astrowind`.
- `vendor/integration/types.d.ts` — `declare module 'astrowind:config'`.
- 15 `src/**` files (utils, layouts, components, pages) — all `import { ... } from 'astrowind:config'` virtual-module consumers.
- `astro.config.ts` — `import astrowind from './vendor/integration'` and the `astrowind({ config: './src/config.yaml' })` call.
- `.vscode/settings.json` + `.vscode/astrowind/config-schema.json` — IDE-local schema.

**Left alone (deliberate — not churn-worthy):**
- `LICENSE.md` — "Copyright (c) 2023 onWidget" retained; MIT license requires the original copyright notice when redistributing.
- ADR references to `@onwidget/astrowind` in earlier phased-upgrade ADRs — accurate historical notes.

**Flagged for you (not touched):**
- `src/pages/terms.md` and `src/pages/privacy.md` — template legal demo text. Needs real copy from you.

## `astro.config.ts` review

- `site:` URL: lives in `src/config.yaml` as `https://ScaleForce.agency` — already correct, not template-origin.
- Analytics: no template-origin analytics IDs in `astro.config.ts`. `src/config.yaml` has `googleAnalytics.id: null` and `googleTags Manager.id: null` (your own config).
- The only AstroWind-flavored code in `astro.config.ts` is the vendored integration import — deferred per scope.

## Test plan

- [x] `npm install` — installs cleanly against the new name.
- [x] `npm run check:astro` — 0 errors, 0 warnings, 0 hints across 95 files.
- [x] `npm run check:eslint` — passes.
- [x] `npm run build` — proceeds through static-build until Contentful client init fails with `Expected parameter accessToken`. This is the **expected failure mode in an environment without secrets**; the README documents the required env vars. Production/staging builds on Netlify have the secrets set and will succeed.
- [ ] Review the README rewrite end-to-end — this is the one content-decision thing in this PR.
- [ ] Decide whether to replace `terms.md` / `privacy.md` template text now or track as a separate task.

## HS-7 manual action

This is the last integration-phase hard-stop before Phase 7 (redesign). Please read the README rewrite in particular — it is the one content decision in this PR that benefits from your eyes. Everything else is mechanical rename / metadata / ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)