### PR TITLE
chore: add Scaleforce copyright to LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2023 onWidget
+Copyright (c) 2026 Scaleforce
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Adds `Copyright (c) 2026 Scaleforce` alongside the preserved onWidget 2023 line
- Follow-up to PR #53 (detach from AstroWind); MIT requires preserving the original copyright

## Test plan
- [x] File change is a single additive line; no functional impact
- [ ] CI green