### PR TITLE
chore: set Dependabot target-branch to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    target-branch: dev
     labels:
       - dependencies
       - ci


### PR DESCRIPTION
## Summary
- Adds `target-branch: dev` to the `github-actions` Dependabot updates entry so Dependabot opens PRs against `dev` instead of the default branch.
- Aligns Dependabot with the repo's `feature -> dev -> main` merge strategy.

## Notes
- Only a `github-actions` updates entry exists today; no `npm` entry to update.

## Test plan
- [ ] Confirm next Dependabot run targets `dev`.