### PR TITLE
chore: remove prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "astro-build.astro-vscode",
     "bradlc.vscode-tailwindcss",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
     "unifiedjs.vscode-mdx"
   ],
   "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
   "files.associations": {
     "*.mdx": "markdown"
   },
-  "prettier.documentSelectors": ["**/*.astro"],
   "[astro]": {
     "editor.defaultFormatter": "astro-build.astro-vscode"
   },


### PR DESCRIPTION
## Summary

Prettier was inherited from the AstroWind template and never actually adopted. Earlier cleanup (see `docs/adr/ADR-2026-04-21-ci-hardening-split-and-eslint-env-override.md`) already stripped prettier from `package.json` scripts/devDependencies, deleted root config files, and removed the `format` CI job. This PR removes the remaining stragglers:

- Drop `esbenp.prettier-vscode` from `.vscode/extensions.json` recommended extensions
- Drop `prettier.documentSelectors` from `.vscode/settings.json`

No code/config changes outside `.vscode/`. Transitive `prettier` / `volar-service-prettier` entries in `package-lock.json` remain — they are pulled in as peer suggestions by `@astrojs/check`'s language server and cannot be pruned without removing the typechecker.

## Test plan

- [x] `npm install` — no package-lock drift
- [x] `npm run check` — astro check and eslint both clean (0 errors, 0 warnings, 0 hints)
- [ ] CI `build` / `typecheck` / `lint` jobs green on this PR (verified by workflow on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)