### PR TITLE
chore: rename astrowind:config virtual module -> site:config

### DIFF
--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -3,7 +3,7 @@
 // TODO: check this against best practices
 import { Image } from 'astro:assets';
 import logo from '../assets/images/logo.png';
-import { SITE } from 'astrowind:config';
+import { SITE } from 'site:config';
 ---
 
 <span

--- a/src/components/blog/GridItem.astro
+++ b/src/components/blog/GridItem.astro
@@ -1,5 +1,5 @@
 ---
-import { APP_BLOG } from 'astrowind:config';
+import { APP_BLOG } from 'site:config';
 import type { Post } from '~/types';
 
 import Image from '~/components/common/Image.astro';

--- a/src/components/blog/ListItem.astro
+++ b/src/components/blog/ListItem.astro
@@ -4,7 +4,7 @@ import { Icon } from 'astro-icon/components';
 import Image from '~/components/common/Image.astro';
 import PostTags from '~/components/blog/Tags.astro';
 
-import { APP_BLOG } from 'astrowind:config';
+import { APP_BLOG } from 'site:config';
 import type { Post } from '~/types';
 
 import { getPermalink } from '~/utils/permalinks';

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -1,5 +1,5 @@
 ---
-import { APP_BLOG } from 'astrowind:config';
+import { APP_BLOG } from 'site:config';
 
 import { getRelatedPosts } from '~/utils/blog';
 import BlogHighlightedPosts from '../widgets/BlogHighlightedPosts.astro';

--- a/src/components/blog/Tags.astro
+++ b/src/components/blog/Tags.astro
@@ -1,7 +1,7 @@
 ---
 import { getPermalink } from '~/utils/permalinks';
 
-import { APP_BLOG } from 'astrowind:config';
+import { APP_BLOG } from 'site:config';
 import type { Post } from '~/types';
 
 export interface Props {

--- a/src/components/blog/ToBlogLink.astro
+++ b/src/components/blog/ToBlogLink.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon } from 'astro-icon/components';
 import { getBlogPermalink } from '~/utils/permalinks';
-import { I18N } from 'astrowind:config';
+import { I18N } from 'site:config';
 import Button from '~/components/ui/Button.astro';
 
 const { textDirection } = I18N;

--- a/src/components/common/Analytics.astro
+++ b/src/components/common/Analytics.astro
@@ -1,6 +1,6 @@
 ---
 import { GoogleAnalytics } from '@astrolib/analytics';
-import { ANALYTICS } from 'astrowind:config';
+import { ANALYTICS } from 'site:config';
 ---
 
 {

--- a/src/components/common/ApplyColorMode.astro
+++ b/src/components/common/ApplyColorMode.astro
@@ -1,5 +1,5 @@
 ---
-import { UI } from 'astrowind:config';
+import { UI } from 'site:config';
 
 // TODO: This code is temporary
 ---

--- a/src/components/common/BasicScripts.astro
+++ b/src/components/common/BasicScripts.astro
@@ -1,5 +1,5 @@
 ---
-import { UI } from 'astrowind:config';
+import { UI } from 'site:config';
 ---
 
 <script is:inline define:vars={{ defaultTheme: UI.theme }}>

--- a/src/components/common/Metadata.astro
+++ b/src/components/common/Metadata.astro
@@ -4,7 +4,7 @@ import { AstroSeo } from '@astrolib/seo';
 
 import type { Props as AstroSeoProps } from '@astrolib/seo';
 
-import { SITE, METADATA, I18N } from 'astrowind:config';
+import { SITE, METADATA, I18N } from 'site:config';
 import type { MetaData } from '~/types';
 import { getCanonical } from '~/utils/permalinks';
 

--- a/src/components/common/SiteVerification.astro
+++ b/src/components/common/SiteVerification.astro
@@ -1,5 +1,5 @@
 ---
-import { SITE } from 'astrowind:config';
+import { SITE } from 'site:config';
 ---
 
 {SITE.googleSiteVerificationId && <meta name="google-site-verification" content={SITE.googleSiteVerificationId} />}

--- a/src/components/common/TagsBody.astro
+++ b/src/components/common/TagsBody.astro
@@ -1,6 +1,6 @@
 ---
 import GoogleTagManagerBody from '../../lib/google-tag-manager/src/GoogleTagManagerBody.astro';
-import { ANALYTICS } from 'astrowind:config';
+import { ANALYTICS } from 'site:config';
 ---
 
 {

--- a/src/components/common/TagsHead.astro
+++ b/src/components/common/TagsHead.astro
@@ -1,6 +1,6 @@
 ---
 import GoogleTagManagerHead from '../../lib/google-tag-manager/src/GoogleTagManagerHead.astro';
-import { ANALYTICS } from 'astrowind:config';
+import { ANALYTICS } from 'site:config';
 ---
 
 {

--- a/src/components/common/ToggleTheme.astro
+++ b/src/components/common/ToggleTheme.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon } from 'astro-icon/components';
 
-import { UI } from 'astrowind:config';
+import { UI } from 'site:config';
 
 export interface Props {
   label?: string;

--- a/src/components/widgets/BlogHighlightedPosts.astro
+++ b/src/components/widgets/BlogHighlightedPosts.astro
@@ -1,5 +1,5 @@
 ---
-import { APP_BLOG } from 'astrowind:config';
+import { APP_BLOG } from 'site:config';
 
 import Grid from '~/components/blog/Grid.astro';
 

--- a/src/components/widgets/BlogLatestPosts.astro
+++ b/src/components/widgets/BlogLatestPosts.astro
@@ -1,5 +1,5 @@
 ---
-import { APP_BLOG } from 'astrowind:config';
+import { APP_BLOG } from 'site:config';
 
 import Grid from '~/components/blog/Grid.astro';
 

--- a/src/components/widgets/Footer.astro
+++ b/src/components/widgets/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import { Icon } from 'astro-icon/components';
-import { SITE } from 'astrowind:config';
+import { SITE } from 'site:config';
 import { getHomePermalink } from '~/utils/permalinks';
 
 interface Link {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,7 @@
 ---
 import '~/assets/styles/tailwind.css';
 
-import { I18N } from 'astrowind:config';
+import { I18N } from 'site:config';
 
 import CommonMeta from '~/components/common/CommonMeta.astro';
 import Favicons from '~/components/Favicons.astro';

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,6 +1,6 @@
 import { getRssString } from '@astrojs/rss';
 
-import { SITE, METADATA, APP_BLOG } from 'astrowind:config';
+import { SITE, METADATA, APP_BLOG } from 'site:config';
 import { fetchPosts } from '~/utils/blog';
 import { getPermalink } from '~/utils/permalinks';
 

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -2,7 +2,7 @@ import type { PaginateFunction } from 'astro';
 import { getCollection, render } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import type { FormattedContentfulPost, Post } from '~/types';
-import { APP_BLOG } from 'astrowind:config';
+import { APP_BLOG } from 'site:config';
 import { cleanSlug, trimSlash, BLOG_BASE, POST_PERMALINK_PATTERN, CATEGORY_BASE, TAG_BASE } from './permalinks';
 
 import { contentfulClient } from "../lib/contentful/contentful";

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -1,6 +1,6 @@
 import slugify from 'limax';
 
-import { SITE, APP_BLOG } from 'astrowind:config';
+import { SITE, APP_BLOG } from 'site:config';
 
 import { trim } from '~/utils/utils';
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { I18N } from 'astrowind:config';
+import { I18N } from 'site:config';
 
 export const formatter: Intl.DateTimeFormat = new Intl.DateTimeFormat(I18N?.language, {
   year: 'numeric',

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,6 +1,6 @@
 Vendored Astro integration originally derived from the AstroWind template.
 
-Provides the `astrowind:config` virtual module (resolved by the Vite plugin
+Provides the `site:config` virtual module (resolved by the Vite plugin
 in `./integration/index.ts`) that exposes parsed `src/config.yaml` values —
 `SITE`, `I18N`, `METADATA`, `APP_BLOG`, `UI`, `ANALYTICS` — to components
 via typed imports.

--- a/vendor/integration/index.ts
+++ b/vendor/integration/index.ts
@@ -22,7 +22,7 @@ export default ({ config: _themeConfig = 'src/config.yaml' } = {}): AstroIntegra
       }) => {
         const buildLogger = logger.fork('astrowind');
 
-        const virtualModuleId = 'astrowind:config';
+        const virtualModuleId = 'site:config';
         const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
         const rawJsonConfig = (await loadConfig(_themeConfig)) as Config;

--- a/vendor/integration/types.d.ts
+++ b/vendor/integration/types.d.ts
@@ -1,4 +1,4 @@
-declare module 'astrowind:config' {
+declare module 'site:config' {
   import type { SiteConfig, I18NConfig, MetaDataConfig, AppBlogConfig, UIConfig, AnalyticsConfig } from './config';
 
   export const SITE: SiteConfig;


### PR DESCRIPTION
## Summary
- Renames the Vite virtual module ID from `astrowind:config` to `site:config` (defined in `vendor/integration/index.ts`).
- Updates the TypeScript module declaration in `vendor/integration/types.d.ts`.
- Updates all 22 import sites under `src/` plus a reference in `vendor/README.md`.
- Deferred follow-up from Phase 6 detach-from-AstroWind-template (see ADR 2026-04-21).

## Why
The `astrowind:` prefix was a holdover from the AstroWind template. Now that the project is detached, the virtual module should be project-owned.

## Test plan
- [x] `npm run check:astro` — 0 errors, 0 warnings, 0 hints across 95 files.
- [x] Confirmed zero remaining references to `astrowind:config` under `src/` or `vendor/` (remaining mentions in `docs/adr/ADR-2026-04-21-*.md` are historical record and intentionally preserved).
- [ ] CI green on PR.

Note: `npm run build` fails locally due to a missing Contentful access token env var; this pre-existed this PR (verified on clean `dev`). Not related to the rename.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)