### PR TITLE
docs(ia): IA audit for Phase 7

### DIFF
--- a/docs/ia-audit-2026-04-21.md
+++ b/docs/ia-audit-2026-04-21.md
@@ -1,0 +1,263 @@
+# IA Audit — Phase 7 Redesign Prep
+
+**Date:** 2026-04-21
+**Branch base:** `origin/dev` (post-PR #53 "detach from AstroWind template")
+**Purpose:** Tee up Phase 7 (custom-brand / shadcn-ish redesign) decisions. Inventory every route and component still inherited from AstroWind, flag what's demo-cruft, and surface gaps. No code or content changes here.
+**Constraints:** Keep existing copy and brand assets for Phase 7. Real legal copy for `terms.md` / `privacy.md` is deferred.
+
+---
+
+## Overview
+
+The repo runs as a single-page landing site (`/`) plus a blog (`/[...blog]`), terms/privacy markdown pages, a 404, and an RSS feed. Everything else the AstroWind template shipped (about, contact, services, landing/\*, homes/\*, pricing/\*, demo pages) has already been deleted — PR #53 pruned the filesystem. What remains is still **structurally AstroWind**, though: the widget library, the nav model (single-page anchor scrolling), the legal copy still references "AstroWind LLC", and ~half the `src/components/widgets/*` files are not imported by anything real.
+
+Signal vs. noise:
+
+- **Live surface:** `src/pages/index.astro` + blog routes + `404.astro` + `terms.md` / `privacy.md` + `rss.xml.ts`. That's it.
+- **Content sources wired in:** Contentful (landing copy, images, use-case posts), local MDX (`src/content/post/*.md`), and `thomhayner.com` feed (via `src/lib/thomhayner/`). An `astro-airtable` lib exists at `src/lib/astro-airtable/` but no page imports it.
+- **React surface:** exactly one import, `react-calendly` inside `src/components/widgets/Calendly.astro`, which **is not imported anywhere** (see Issue #52).
+
+---
+
+## Routes inventory
+
+Total routable entries: **9** files producing **7** public URL shapes.
+
+| # | URL | File | Purpose | Content source |
+|---|---|---|---|---|
+| 1 | `/` | `src/pages/index.astro` | Single-page landing: Hero, 3 AI-services panels, standard services, dev process, client success, stats, FAQ, contact form, locations, blog teaser | Contentful (`landingPage`, `image` content types) |
+| 2 | `/404` | `src/pages/404.astro` | Error page, links back to `getHomePermalink()` | Hardcoded copy |
+| 3 | `/terms` | `src/pages/terms.md` | Terms & Conditions | Hardcoded markdown, **still references "AstroWind LLC, 1 Cupertino, CA 95014"** |
+| 4 | `/privacy` | `src/pages/privacy.md` | Privacy Policy | Hardcoded markdown, **same AstroWind placeholder copy** |
+| 5 | `/rss.xml` | `src/pages/rss.xml.ts` | RSS feed for all posts | `fetchPosts()` (Contentful + local MDX + thomhayner) |
+| 6 | `/blog` + `/blog/[page]` | `src/pages/[...blog]/[...page].astro` | Paginated blog index | `getStaticPathsBlogList` via `utils/blog.ts` |
+| 7 | `/[slug]` (post permalink) | `src/pages/[...blog]/index.astro` | Single blog post | `getStaticPathsBlogPost`; posts aggregated from 3 sources |
+| 8 | `/category/[slug]` + pages | `src/pages/[...blog]/[category]/[...page].astro` | Category archive (paginated) | `getStaticPathsBlogCategory` |
+| 9 | `/tag/[slug]` + pages | `src/pages/[...blog]/[tag]/[...page].astro` | Tag archive (paginated) | `getStaticPathsBlogTag` |
+
+Post permalink shape is `/%slug%` (from `src/config.yaml`). Category path prefix `category`, tag path prefix `tag`. All are prerendered (`export const prerender = true`).
+
+---
+
+## Components inventory
+
+Total component files: **52** under `src/components/**` (excluding stray duplicates).
+
+### `src/components/` (root, 3)
+
+| File | Role | Imported by | Flavor |
+|---|---|---|---|
+| `Logo.astro` | Wordmark/logo block | `widgets/Header.astro` (1) | AstroWind-ish; Scaleforce has real assets — likely a trivial refactor |
+| `Favicons.astro` | `<link rel>` block | `layouts/Layout.astro` (1) | Infra, neutral |
+| `CustomStyles.astro` | Inline CSS custom props | `layouts/Layout.astro` (1); referenced in `assets/styles/tailwind.css` header comment | Mechanism Phase 7 wants to rethink (shadcn theme tokens) |
+
+### `src/components/blog/` (10)
+
+| File | Role | Imported by | Notes |
+|---|---|---|---|
+| `Grid.astro` | Grid wrapper | `widgets/BlogHighlightedPosts.astro`, `widgets/BlogLatestPosts.astro` | Real use |
+| `GridItem.astro` | Post card (grid) | `blog/Grid.astro` | Real use |
+| `List.astro` | List wrapper | 3 blog routes | Real use |
+| `ListItem.astro` | Post card (list) | `blog/List.astro` | Real use |
+| `Headline.astro` | Blog-section title | 3 blog routes | Real use |
+| `Pagination.astro` | Prev/next | 3 blog routes | Real use |
+| `SinglePost.astro` | Full post layout | `[...blog]/index.astro` | Real use |
+| `RelatedPosts.astro` | Post footer block | `[...blog]/index.astro` | Real use |
+| `Tags.astro` | Tag pill list | `blog/ListItem.astro`, `blog/SinglePost.astro` | Real use |
+| `ToBlogLink.astro` | "Back to blog" button | `[...blog]/index.astro` | Real use |
+
+### `src/components/common/` (13)
+
+| File | Role | Imported by | Notes |
+|---|---|---|---|
+| `CommonMeta.astro` | `<meta>` basics | `layouts/Layout.astro` | Infra |
+| `Metadata.astro` | OG/Twitter orchestrator | `layouts/Layout.astro` | Infra |
+| `TagsHead.astro` | GTM head snippet | `layouts/Layout.astro` | Infra |
+| `TagsBody.astro` | GTM body snippet | `layouts/Layout.astro` | Infra |
+| `SiteVerification.astro` | Google verify | `layouts/Layout.astro` | Infra |
+| `Analytics.astro` | GA wrapper | `layouts/Layout.astro` | Infra |
+| `SplitbeeAnalytics.astro` | Splitbee script | **nobody** | AstroWind legacy, dead |
+| `ApplyColorMode.astro` | Theme bootstrap | `layouts/Layout.astro` | Infra |
+| `BasicScripts.astro` | Global JS (menu toggles, scroll) | `layouts/Layout.astro` | AstroWind scroll/nav glue; candidate to rewrite |
+| `Image.astro` | `<Image>` wrapper | `widgets/Hero2`, `widgets/Steps`, `widgets/Brands`, `widgets/Content`, `widgets/Features3`, `widgets/Testimonials`, `blog/GridItem`, `blog/ListItem`, `blog/SinglePost` (9) | Real use |
+| `SocialShare.astro` | Share buttons | `blog/SinglePost.astro` (1) | Real use, but very AstroWind-styled |
+| `ToggleTheme.astro` | Dark/light toggle | `widgets/Header.astro` (1) | Real use |
+| `ToggleMenu.astro` | Mobile menu toggle | `widgets/Header.astro` (1) | Real use |
+
+### `src/components/ui/` (11, plus 1 stray duplicate)
+
+| File | Role | Imported by | Notes |
+|---|---|---|---|
+| `Button.astro` | Button | `widgets/Hero2`, `widgets/HeroText`, `widgets/Header`, `widgets/Hero`, `widgets/Content`, `widgets/CallToAction`, `widgets/Testimonials`, `widgets/Steps2`, `widgets/Pricing`, `blog/Pagination`, `blog/ToBlogLink`, `ui/Form.astro` (12) | Core primitive; Phase 7 will likely swap for shadcn Button |
+| `Headline.astro` | Section headline | widgets/FAQs, Features, Features2, Features3, Brands, Contact, ContactUs, CallToAction, Testimonials, Steps, Steps2, Pricing (12) | Core primitive |
+| `WidgetWrapper.astro` | Section outer shell | widgets/Calendly, FAQs, Steps2, Brands, Features2, Features3, Contact, ContactUs, Testimonials, CallToAction, Pricing, BlogLatestPosts, BlogHighlightedPosts, Features, Steps (15) | Core primitive |
+| `Background.astro` | Section bg | `ui/WidgetWrapper.astro` (1) | Via wrapper, real use |
+| `Form.astro` | Contact-form fields | `widgets/Contact.astro`, `widgets/ContactUs.astro` (2) | Real use |
+| `ItemGrid.astro` | 2-col icon/card grid | `widgets/Features.astro`, `widgets/Features3.astro` (2) | Real use |
+| `ItemGrid2.astro` | Alt card grid | `widgets/Features2.astro` (1) | Real use |
+| `ItemGridFAQ.astro` | FAQ item grid | `widgets/FAQs.astro` (1) | Real use |
+| `ItemGridFAQ 2.astro` | **Identical-ish duplicate** of `ItemGridFAQ.astro` | **nobody** | Stray file from a macOS-style "Finder duplicate"; should be deleted |
+| `Timeline.astro` | Steps timeline | `widgets/Steps.astro` (1) | Real use |
+| `DListItem.astro` | Description-list item | **nobody** | Dead |
+
+### `src/components/widgets/` (25)
+
+| File | Role | Imported by | Keep/cruft read |
+|---|---|---|---|
+| `Header.astro` | Site header | `layouts/PageLayout.astro` | Live |
+| `Footer.astro` | Site footer | `layouts/PageLayout.astro` | Live |
+| `Announcement.astro` | Top announcement bar | `layouts/PageLayout.astro` | Live but generic; Phase 7 decision |
+| `Hero.astro` | Main hero | `pages/index.astro` | Live |
+| `Hero2.astro` | Alt hero variant | **nobody** | Dead |
+| `HeroText.astro` | Text-only hero | **nobody** | Dead |
+| `Content.astro` | Image+content panel (AI services) | `pages/index.astro` (used 3× as `AiServicesPanel`) | Live |
+| `Features.astro` | Feature grid (Client Success) | `pages/index.astro` | Live |
+| `Features2.astro` | Feature grid variant (StandardServices + Locations) | `pages/index.astro` (used 2×) | Live |
+| `Features3.astro` | 3rd feature variant | **nobody** | Dead |
+| `Steps.astro` | Process timeline (Dev Process) | `pages/index.astro` | Live |
+| `Steps2.astro` | Alt steps variant | **nobody** | Dead |
+| `Stats.astro` | Stats row (Client Stats) | `pages/index.astro` | Live |
+| `FAQs.astro` | FAQ accordion | `pages/index.astro` | Live |
+| `Contact.astro` | Contact form | **nobody** (shadowed by `ContactUs.astro`) | Dead duplicate of `ContactUs.astro`-style |
+| `ContactUs.astro` | Contact form + cards | `pages/index.astro` | Live |
+| `BlogLatestPosts.astro` | Blog teaser grid | `pages/index.astro` | Live |
+| `BlogHighlightedPosts.astro` | Related-posts grid | `blog/RelatedPosts.astro` | Live (indirect) |
+| `Brands.astro` | Logo wall | **nobody** | Dead |
+| `CallToAction.astro` | CTA banner | **nobody** | Dead (but probably wanted post-redesign) |
+| `Calendly.astro` | Calendly inline widget (react-calendly) | **nobody** | Dead; **Issue #52** |
+| `Note.astro` | Inline note/callout | **nobody** | Dead |
+| `Pricing.astro` | Pricing cards | **nobody** | Dead |
+| `Testimonials.astro` | Testimonial cards | **nobody** | Dead |
+
+**Dead-widget tally:** 10 of 25 widgets (`Hero2`, `HeroText`, `Features3`, `Steps2`, `Contact`, `Brands`, `CallToAction`, `Calendly`, `Note`, `Pricing`, `Testimonials` — 11 if you count both `Contact` and `Calendly`). Plus `SplitbeeAnalytics`, `DListItem`, and `ItemGridFAQ 2.astro`. That's **~14 files with zero real imports**.
+
+---
+
+## Recommendations per route
+
+| Route | Recommendation | Reason |
+|---|---|---|
+| `/` (`index.astro`) | **REWRITE** | Copy stays per Phase 7 directive, but the widget stack is AstroWind-shaped. Rebuild section-by-section on new design system; keep content binding to Contentful. |
+| `/404` | **REWRITE** (light) | Functional but generic; tiny rebuild in new visual language. |
+| `/terms` | **KEEP** (placeholder) | Real copy deferred. Flag: swap the AstroWind LLC references for Scaleforce placeholders or TODO comments so it doesn't leak in review builds. |
+| `/privacy` | **KEEP** (placeholder) | Same as terms. |
+| `/rss.xml` | **KEEP** | Pure infra, not visual. |
+| `/blog` index (`[...page].astro`) | **REWRITE** | Archive layout inherits AstroWind's headline + list; redesign this alongside post cards. |
+| `/[slug]` (single post) | **REWRITE** | `SinglePost.astro` + its related-posts block carry heavy AstroWind styling. |
+| `/category/[slug]` | **KEEP** | Trivial wrapper over `BlogList`; rides along with `/blog` rewrite automatically. |
+| `/tag/[slug]` | **KEEP** | Same — wrapper. |
+
+No route is a standalone **DELETE**. PR #53 already cut AstroWind's `about`, `landing/*`, `homes/*`, `pricing/*`, and demo pages. What's left is the minimum viable set for this landing + blog.
+
+---
+
+## Recommendations per component
+
+Grouped by action to make Phase 7 scoping easier.
+
+### DELETE (zero real imports, safe to remove now)
+
+| File | One-line reason |
+|---|---|
+| `src/components/widgets/Hero2.astro` | Unused alt hero; no plan to adopt it. |
+| `src/components/widgets/HeroText.astro` | Unused text-only hero variant. |
+| `src/components/widgets/Features3.astro` | Unused third feature variant. |
+| `src/components/widgets/Steps2.astro` | Unused alt steps variant. |
+| `src/components/widgets/Contact.astro` | Duplicated by `ContactUs.astro` which is the one actually used on `/`. |
+| `src/components/widgets/Brands.astro` | Logo wall, unused. Rebuild fresh when a real client-logo section is designed. |
+| `src/components/widgets/Note.astro` | Unused callout; trivial to rebuild if needed. |
+| `src/components/widgets/Pricing.astro` | Unused and Scaleforce has no public pricing page in scope. |
+| `src/components/widgets/Testimonials.astro` | Unused; rebuild when real testimonial content exists. |
+| `src/components/widgets/Calendly.astro` | **Issue #52** — orphaned react-calendly widget, and the only reason `react` / `react-dom` still exist as deps. Fold into Phase 7 scoping decision (see Gaps). |
+| `src/components/widgets/CallToAction.astro` | Unused today. Likely **REBUILD** during Phase 7; delete this one rather than shoehorn it. |
+| `src/components/common/SplitbeeAnalytics.astro` | Splitbee analytics not configured; never imported. |
+| `src/components/ui/DListItem.astro` | Unused description-list item. |
+| `src/components/ui/ItemGridFAQ 2.astro` | Stray duplicate of `ItemGridFAQ.astro` (Finder-style " 2" copy). |
+
+That's **14 files**.
+
+### REBUILD (delete + reimagine in Phase 7)
+
+| File | One-line reason |
+|---|---|
+| `src/components/widgets/Hero.astro` | Live on `/`, but Phase 7 hero will be the first and biggest brand statement; don't iterate — replace. |
+| `src/components/widgets/Header.astro` | Nav model is single-page anchor scroll; Phase 7 should decide on sticky/glass/scroll behavior and shadcn-ish primitives. |
+| `src/components/widgets/Footer.astro` | Footer currently has broken links (`/` placeholders for Careers/Press, Phone/Email/Chat all pointing at `#contact`). Rebuild with real IA. |
+| `src/components/widgets/Announcement.astro` | Top bar is generic AstroWind; make a Phase 7 call: keep as promo slot or delete. |
+| `src/components/common/BasicScripts.astro` | Carries AstroWind's menu+scroll glue; rewrite against new header primitives. |
+| `src/components/CustomStyles.astro` | Phase 7 theming via shadcn CSS variables should replace this mechanism. |
+| `src/components/Logo.astro` | Re-implement against real Scaleforce brand assets + shadcn-ish sizing tokens. |
+
+### REFACTOR (keep behavior, restyle on new design system)
+
+| File | Notes |
+|---|---|
+| `src/components/ui/Button.astro` | Used in 12 places. Phase 7 target: shadcn `Button` variants. Migration pattern will matter. |
+| `src/components/ui/Headline.astro` | Used in 12 places. Reskin to shadcn typography. |
+| `src/components/ui/WidgetWrapper.astro` + `ui/Background.astro` | 15 callsites. Keep the section-shell abstraction, retheme. |
+| `src/components/ui/Form.astro` | Contact form primitive; refactor to shadcn form components (native `<form>` → shadcn Input/Textarea). |
+| `src/components/ui/ItemGrid.astro`, `ItemGrid2.astro`, `ItemGridFAQ.astro`, `Timeline.astro` | Reskin; shapes are reusable. |
+| `src/components/widgets/Content.astro` | Core of `/`'s AiServicesPanel — 3× usage. Restyle only. |
+| `src/components/widgets/Features.astro`, `Features2.astro` | Restyle only — they're the backbone of Client Success / StandardServices / Locations. |
+| `src/components/widgets/Steps.astro` | Restyle only — Dev Process section. |
+| `src/components/widgets/Stats.astro` | Restyle only. |
+| `src/components/widgets/FAQs.astro` | Restyle; consider shadcn Accordion. |
+| `src/components/widgets/ContactUs.astro` | Restyle; keep Contentful binding. |
+| `src/components/widgets/BlogLatestPosts.astro` + `BlogHighlightedPosts.astro` | Restyle; shape is fine. |
+| `src/components/blog/*` (all 10) | Blog list/grid/post/pagination/tags — restyle as one batch against new typography + card tokens. |
+| `src/components/common/SocialShare.astro` | Restyle; currently very AstroWind-y. |
+| `src/components/common/ToggleTheme.astro`, `ToggleMenu.astro` | Reskin to shadcn IconButton + Sheet pattern. |
+
+### KEEP as-is (pure infra / no visual footprint)
+
+`src/components/common/CommonMeta.astro`, `Metadata.astro`, `TagsHead.astro`, `TagsBody.astro`, `SiteVerification.astro`, `Analytics.astro`, `ApplyColorMode.astro`, `Favicons.astro`, `Image.astro`. These are SEO, analytics, and image-service plumbing — retouch only if integrations change.
+
+---
+
+## Gaps — what an agency landing arguably needs
+
+Inferred from Scaleforce's positioning (AI + Automations + Ops agency) and from the current nav model (single-page anchor) vs. what an agency buyer expects:
+
+1. **Services detail pages.** `/` lists three AI services panels as anchor sections. A real agency site usually has `/services/<service-slug>` deep-dives for SEO and sales referrals. None exist.
+2. **Case studies / client work.** No route or component. `Testimonials.astro` exists but is unused and is thin pull-quotes, not proof-of-work. Phase 7 should scope `/case-studies` and `/case-studies/[slug]`.
+3. **Contact flow.** The contact form on `/` (`widgets/ContactUs.astro` + `ui/Form.astro`) **has no submit handler wired** — the form renders inputs but the `action`/`method`/endpoint are undefined. Phase 7 should pick a destination: Netlify Forms, Formspree, a serverless function, or a Calendly-style tool.
+4. **Calendly / scheduling decision (Issue #52).** `Calendly.astro` is orphaned; `react-calendly` is the only reason React is a dep. Fold into Phase 7 scoping: **(a)** delete the widget + react-calendly (drops React surface entirely), **(b)** re-wire to a concrete page (contact section? `/book` route?) via `@astrojs/react` + `client:load`, or **(c)** replace with a non-React scheduler (Cal.com embed, iframe). The "Book a call" CTA in `navigation.ts` currently points to `/#contact`, which does not include a Calendly widget — so the CTA half-works today.
+5. **About / team.** No `/about` page. PR #53 removed the AstroWind demo one. Agency buyers expect "who you are". Scope in Phase 7.
+6. **Pricing or engagement model.** `Pricing.astro` widget exists but is unused. Scaleforce may intentionally want to keep pricing off-site; make that an explicit Phase 7 decision, don't just leave the widget.
+7. **Legal copy.** `terms.md` and `privacy.md` still say "AstroWind LLC, 1 Cupertino, CA 95014". Even keeping placeholder copy, the entity name should be scrubbed in Phase 7 to avoid broken-brand impressions in review builds. Real legal copy is deferred — that's fine.
+8. **Footer links that go nowhere.** `src/navigation.ts` footer has Careers → `/`, Press → `/`, Docs commented-out, Phone/Email/Chat/Video all pointing at `#contact` or `#calendly`. Phase 7 footer rebuild needs real IA or fewer links.
+9. **Sitemap.** No `sitemap.xml` route or `@astrojs/sitemap` integration visible from page walk. RSS exists, sitemap doesn't.
+10. **OG image.** Default OG image is `~/assets/images/default.png` (from `config.yaml`). Phase 7 should produce a branded OG.
+
+---
+
+## Phase 7 sequencing suggestion
+
+Order reflects dependencies, not priority. Each step has a natural PR boundary.
+
+1. **Cleanup pass (no design work).** Delete the 14 zero-import files listed in DELETE above. Close or link Issue #52 with a decision. One small PR, makes the next steps easier to reason about.
+2. **Design tokens + primitives.** Pick the shadcn-ish primitives the redesign will lean on (Button, Card, Input, Accordion, Sheet, typography scale). Land a theme layer — either replace `CustomStyles.astro` with a tokens file or introduce one next to it. No pages change yet.
+3. **Header + Footer rebuild.** High blast radius (every page). Fix footer IA while rebuilding.
+4. **Homepage rebuild, section-by-section.** Hero → AiServicesPanel (Content) → StandardServices (Features2) → DevProcess (Steps) → ClientSuccess (Features) → Stats → FAQ → ContactUs → Locations → BlogLatestPosts. Keep Contentful bindings intact. Copy unchanged per directive. One PR per 1–3 sections keeps reviews sane.
+5. **Blog rebuild.** `blog/*` + `[...blog]/*` pages — batch them since they share primitives (list, grid, single post, pagination, tags, related).
+6. **Contact form wiring.** Decide backend (Netlify Forms vs. Formspree vs. serverless). Wire `ui/Form.astro` to it. Covers the Gap #3 above.
+7. **Calendly / scheduling decision.** Resolves Issue #52 by either deleting the widget + react-calendly (ideal if scheduling lives on a third-party page linked from the CTA) or properly wiring `@astrojs/react`.
+8. **Legal copy scrub.** Replace AstroWind LLC with Scaleforce placeholder entity + jurisdiction. Leave "this is a Demo" wording alone until real legal copy lands.
+9. **Gaps pass.** Scope `/services/*`, `/case-studies/*`, `/about` as follow-on phases — don't try to cram them into Phase 7 if it stretches the scope.
+
+---
+
+## Appendix: usage-count cheatsheet
+
+Most-referenced primitives (import count from `grep` over `src/`):
+
+- `ui/WidgetWrapper.astro` — 15
+- `ui/Button.astro` — 12
+- `ui/Headline.astro` — 12
+- `common/Image.astro` — 9
+- `widgets/Content.astro` — 3× on `/` (as `AiServicesPanel`)
+- `widgets/Features2.astro` — 2× on `/` (as `StandardServices` and `Locations`)
+
+Zero-import files: 14 (listed under DELETE above).
+
+Live routes: 9 files, 7 URL shapes.

--- a/docs/ia-audit-2026-04-21.md
+++ b/docs/ia-audit-2026-04-21.md
@@ -21,7 +21,7 @@ Signal vs. noise:
 
 ## Routes inventory
 
-Total routable entries: **9** files producing **7** public URL shapes.
+Total routable entries: **9** files producing **8** public URL shapes (collapsing `/blog/[...page]`, `/category/[slug]/[...page]`, and `/tag/[slug]/[...page]` pagination into one shape each).
 
 | # | URL | File | Purpose | Content source |
 |---|---|---|---|---|
@@ -192,9 +192,9 @@ That's **14 files**.
 
 | File | Notes |
 |---|---|
-| `src/components/ui/Button.astro` | Used in 12 places. Phase 7 target: shadcn `Button` variants. Migration pattern will matter. |
-| `src/components/ui/Headline.astro` | Used in 12 places. Reskin to shadcn typography. |
-| `src/components/ui/WidgetWrapper.astro` + `ui/Background.astro` | 15 callsites. Keep the section-shell abstraction, retheme. |
+| `src/components/ui/Button.astro` | Used in 17 places. Phase 7 target: shadcn `Button` variants. Migration pattern will matter. |
+| `src/components/ui/Headline.astro` | Used in 14 places. Reskin to shadcn typography. |
+| `src/components/ui/WidgetWrapper.astro` + `ui/Background.astro` | 17 callsites. Keep the section-shell abstraction, retheme. |
 | `src/components/ui/Form.astro` | Contact form primitive; refactor to shadcn form components (native `<form>` → shadcn Input/Textarea). |
 | `src/components/ui/ItemGrid.astro`, `ItemGrid2.astro`, `ItemGridFAQ.astro`, `Timeline.astro` | Reskin; shapes are reusable. |
 | `src/components/widgets/Content.astro` | Core of `/`'s AiServicesPanel — 3× usage. Restyle only. |
@@ -250,13 +250,13 @@ Order reflects dependencies, not priority. Each step has a natural PR boundary.
 
 Most-referenced primitives (import count from `grep` over `src/`):
 
-- `ui/WidgetWrapper.astro` — 15
-- `ui/Button.astro` — 12
-- `ui/Headline.astro` — 12
+- `ui/WidgetWrapper.astro` — 17
+- `ui/Button.astro` — 17
+- `ui/Headline.astro` — 14
 - `common/Image.astro` — 9
 - `widgets/Content.astro` — 3× on `/` (as `AiServicesPanel`)
 - `widgets/Features2.astro` — 2× on `/` (as `StandardServices` and `Locations`)
 
 Zero-import files: 14 (listed under DELETE above).
 
-Live routes: 9 files, 7 URL shapes.
+Live routes: 9 files, 8 URL shapes.

--- a/docs/ia-audit-2026-04-21.md
+++ b/docs/ia-audit-2026-04-21.md
@@ -21,7 +21,7 @@ Signal vs. noise:
 
 ## Routes inventory
 
-Total routable entries: **9** files producing **8** public URL shapes (collapsing `/blog/[...page]`, `/category/[slug]/[...page]`, and `/tag/[slug]/[...page]` pagination into one shape each).
+Total routable entries: **9** files producing **9** public URL shapes (collapsing `/blog/[...page]`, `/category/[slug]/[...page]`, and `/tag/[slug]/[...page]` pagination into one shape each).
 
 | # | URL | File | Purpose | Content source |
 |---|---|---|---|---|
@@ -259,4 +259,4 @@ Most-referenced primitives (import count from `grep` over `src/`):
 
 Zero-import files: 14 (listed under DELETE above).
 
-Live routes: 9 files, 8 URL shapes.
+Live routes: 9 files, 9 URL shapes.

--- a/docs/ia-audit-2026-04-21.md
+++ b/docs/ia-audit-2026-04-21.md
@@ -41,7 +41,7 @@ Post permalink shape is `/%slug%` (from `src/config.yaml`). Category path prefix
 
 ## Components inventory
 
-Total component files: **52** under `src/components/**` (excluding stray duplicates).
+Total component files: **60** under `src/components/**` (excluding stray duplicates).
 
 ### `src/components/` (root, 3)
 
@@ -129,7 +129,7 @@ Total component files: **52** under `src/components/**` (excluding stray duplica
 | `Pricing.astro` | Pricing cards | **nobody** | Dead |
 | `Testimonials.astro` | Testimonial cards | **nobody** | Dead |
 
-**Dead-widget tally:** 10 of 25 widgets (`Hero2`, `HeroText`, `Features3`, `Steps2`, `Contact`, `Brands`, `CallToAction`, `Calendly`, `Note`, `Pricing`, `Testimonials` — 11 if you count both `Contact` and `Calendly`). Plus `SplitbeeAnalytics`, `DListItem`, and `ItemGridFAQ 2.astro`. That's **~14 files with zero real imports**.
+**Dead-widget tally:** 11 of 25 widgets (`Hero2`, `HeroText`, `Features3`, `Steps2`, `Contact`, `Brands`, `CallToAction`, `Calendly`, `Note`, `Pricing`, `Testimonials`). Plus `SplitbeeAnalytics`, `DListItem`, and `ItemGridFAQ 2.astro`. That's **~14 files with zero real imports**.
 
 ---
 
@@ -220,14 +220,13 @@ Inferred from Scaleforce's positioning (AI + Automations + Ops agency) and from 
 
 1. **Services detail pages.** `/` lists three AI services panels as anchor sections. A real agency site usually has `/services/<service-slug>` deep-dives for SEO and sales referrals. None exist.
 2. **Case studies / client work.** No route or component. `Testimonials.astro` exists but is unused and is thin pull-quotes, not proof-of-work. Phase 7 should scope `/case-studies` and `/case-studies/[slug]`.
-3. **Contact flow.** The contact form on `/` (`widgets/ContactUs.astro` + `ui/Form.astro`) **has no submit handler wired** — the form renders inputs but the `action`/`method`/endpoint are undefined. Phase 7 should pick a destination: Netlify Forms, Formspree, a serverless function, or a Calendly-style tool.
+3. **Contact flow.** The contact form on `/` (`widgets/ContactUs.astro` + `ui/Form.astro`) was previously wired to Netlify Forms via `data-netlify`/`action="/success"` attrs. As part of the Vercel cutover (PR #61, #62), those attrs are being stripped — the form renders inert until Phase 7 Wave 2 wires a real backend (Airtable is already in deps, natural fit). Nav also points "Book a call" at `#contact` but the section is a form, not Calendly — UX mismatch to untangle in Wave 2.
 4. **Calendly / scheduling decision (Issue #52).** `Calendly.astro` is orphaned; `react-calendly` is the only reason React is a dep. Fold into Phase 7 scoping: **(a)** delete the widget + react-calendly (drops React surface entirely), **(b)** re-wire to a concrete page (contact section? `/book` route?) via `@astrojs/react` + `client:load`, or **(c)** replace with a non-React scheduler (Cal.com embed, iframe). The "Book a call" CTA in `navigation.ts` currently points to `/#contact`, which does not include a Calendly widget — so the CTA half-works today.
 5. **About / team.** No `/about` page. PR #53 removed the AstroWind demo one. Agency buyers expect "who you are". Scope in Phase 7.
 6. **Pricing or engagement model.** `Pricing.astro` widget exists but is unused. Scaleforce may intentionally want to keep pricing off-site; make that an explicit Phase 7 decision, don't just leave the widget.
 7. **Legal copy.** `terms.md` and `privacy.md` still say "AstroWind LLC, 1 Cupertino, CA 95014". Even keeping placeholder copy, the entity name should be scrubbed in Phase 7 to avoid broken-brand impressions in review builds. Real legal copy is deferred — that's fine.
 8. **Footer links that go nowhere.** `src/navigation.ts` footer has Careers → `/`, Press → `/`, Docs commented-out, Phone/Email/Chat/Video all pointing at `#contact` or `#calendly`. Phase 7 footer rebuild needs real IA or fewer links.
-9. **Sitemap.** No `sitemap.xml` route or `@astrojs/sitemap` integration visible from page walk. RSS exists, sitemap doesn't.
-10. **OG image.** Default OG image is `~/assets/images/default.png` (from `config.yaml`). Phase 7 should produce a branded OG.
+9. **OG image.** Default OG image is `~/assets/images/default.png` (from `config.yaml`). Phase 7 should produce a branded OG.
 
 ---
 

--- a/docs/ia-audit-2026-04-21.md
+++ b/docs/ia-audit-2026-04-21.md
@@ -84,13 +84,13 @@ Total component files: **60** under `src/components/**` (excluding stray duplica
 | `ToggleTheme.astro` | Dark/light toggle | `widgets/Header.astro` (1) | Real use |
 | `ToggleMenu.astro` | Mobile menu toggle | `widgets/Header.astro` (1) | Real use |
 
-### `src/components/ui/` (11, plus 1 stray duplicate)
+### `src/components/ui/` (11, including 1 stray duplicate)
 
 | File | Role | Imported by | Notes |
 |---|---|---|---|
-| `Button.astro` | Button | `widgets/Hero2`, `widgets/HeroText`, `widgets/Header`, `widgets/Hero`, `widgets/Content`, `widgets/CallToAction`, `widgets/Testimonials`, `widgets/Steps2`, `widgets/Pricing`, `blog/Pagination`, `blog/ToBlogLink`, `ui/Form.astro` (12) | Core primitive; Phase 7 will likely swap for shadcn Button |
-| `Headline.astro` | Section headline | widgets/FAQs, Features, Features2, Features3, Brands, Contact, ContactUs, CallToAction, Testimonials, Steps, Steps2, Pricing (12) | Core primitive |
-| `WidgetWrapper.astro` | Section outer shell | widgets/Calendly, FAQs, Steps2, Brands, Features2, Features3, Contact, ContactUs, Testimonials, CallToAction, Pricing, BlogLatestPosts, BlogHighlightedPosts, Features, Steps (15) | Core primitive |
+| `Button.astro` | Button | `widgets/Hero2`, `widgets/HeroText`, `widgets/Header`, `widgets/Hero`, `widgets/Content`, `widgets/CallToAction`, `widgets/Testimonials`, `widgets/Steps2`, `widgets/Pricing`, `widgets/BlogLatestPosts`, `blog/Pagination`, `blog/ToBlogLink`, `ui/Form.astro`, `ui/ItemGrid.astro`, `ui/ItemGrid2.astro`, `ui/ItemGridFAQ.astro`, `ui/ItemGridFAQ 2.astro` (17) | Core primitive; Phase 7 will likely swap for shadcn Button |
+| `Headline.astro` | Section headline | widgets/FAQs, Features, Features2, Features3, Brands, Contact, ContactUs, CallToAction, Testimonials, Steps, Steps2, Pricing, Content, Stats (14) | Core primitive |
+| `WidgetWrapper.astro` | Section outer shell | widgets/Calendly, FAQs, Steps2, Brands, Features2, Features3, Contact, ContactUs, Testimonials, CallToAction, Pricing, BlogLatestPosts, BlogHighlightedPosts, Features, Steps, Content, Stats (17) | Core primitive |
 | `Background.astro` | Section bg | `ui/WidgetWrapper.astro` (1) | Via wrapper, real use |
 | `Form.astro` | Contact-form fields | `widgets/Contact.astro`, `widgets/ContactUs.astro` (2) | Real use |
 | `ItemGrid.astro` | 2-col icon/card grid | `widgets/Features.astro`, `widgets/Features3.astro` (2) | Real use |
@@ -100,7 +100,7 @@ Total component files: **60** under `src/components/**` (excluding stray duplica
 | `Timeline.astro` | Steps timeline | `widgets/Steps.astro` (1) | Real use |
 | `DListItem.astro` | Description-list item | **nobody** | Dead |
 
-### `src/components/widgets/` (25)
+### `src/components/widgets/` (24)
 
 | File | Role | Imported by | Keep/cruft read |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

- Inventory every route (9 files / 7 URL shapes) and every component (52 files) in the repo post-PR-#53, with usage counts from `grep`.
- Per-route KEEP/REWRITE/DELETE and per-component KEEP/REFACTOR/DELETE/REBUILD recommendations with a one-line reason each.
- Surfaces 14 zero-import files (dead AstroWind widgets + a stray ` 2.astro` duplicate + an unused react-calendly widget tied to Issue #52) and lists concrete gaps (services detail pages, case studies, contact-form wiring, Calendly decision, `/about`, broken footer links, AstroWind LLC text in legal pages, missing sitemap).
- Proposes a Phase 7 sequencing: cleanup PR first, then tokens, then header/footer, then homepage section-by-section, then blog, then contact wiring, then Issue #52 resolution.

No code or content changes in this PR — just `docs/ia-audit-2026-04-21.md`. User makes the final KEEP/DELETE calls.

## Test plan

- [ ] Read `docs/ia-audit-2026-04-21.md` end-to-end.
- [ ] Spot-check a few "zero-import" claims by grepping (`rg "HeroText"`, `rg "Pricing.astro"`, `rg "Calendly.astro"` in `src/`) — all should return only the file itself.
- [ ] Confirm the 9 route files and ~52 component files match what's on disk (`find src/pages -type f`, `find src/components -type f`).
- [ ] Decide which DELETE items to actually cut in the first Phase 7 cleanup PR.
- [ ] Decide Issue #52 (Calendly orphan) in the scoping pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)