### PR TITLE
chore: drop Netlify config (consolidate on Vercel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Marketing and lead-generation site for [ScaleForce.agency](https://ScaleForce.agency), an AI / automations / operations agency. Built with Astro 5 and Tailwind 4, with blog content aggregated from local markdown, Contentful, and the author's personal blog at `thomhayner.com`.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/6827720e-01b1-4d10-a380-6e58995a83d3/deploy-status)](https://app.netlify.com/sites/scaleforce/deploys)
-
 ## Quick start
 
 ```bash
@@ -17,7 +15,7 @@ Dev server defaults to `http://localhost:4321`.
 
 ## Required environment variables
 
-The build pulls content from external sources and will fail without these set (see the deploy environment in Netlify, or a local `.env` for development):
+The build pulls content from external sources and will fail without these set (see the deploy environment in Vercel, or a local `.env` for development):
 
 | Variable | Purpose |
 | --- | --- |
@@ -50,7 +48,7 @@ The Airtable integration is not currently wired into the default build but the e
 - [React 19](https://react.dev/) — used for Calendly embeds and isolated interactive components.
 - [Node 22+](https://nodejs.org/) — required runtime for local dev and CI.
 - [Contentful](https://www.contentful.com/) — CMS for blog / case-study content.
-- [Netlify](https://www.netlify.com/) — production hosting.
+- [Vercel](https://vercel.com/) — production hosting.
 
 ## Branching workflow
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,0 @@
-[build]
-  publish = "dist"
-  command = "npm run build"
-[build.processing.html]
-  pretty_urls = false
-[[headers]]
-  for = "/_astro/*"
-  [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"

--- a/public/_headers
+++ b/public/_headers
@@ -1,2 +1,0 @@
-/_astro/*
-  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary

Drops Netlify-specific build + host config now that production hosting is being consolidated on Vercel (the repo already has a Vercel project running preview builds on every PR).

### Files removed
- `netlify.toml` — Netlify build config + `/_astro/*` cache-control headers. Cache-control is already mirrored in `vercel.json`.
- `public/_headers` — Netlify-style static headers (identical `/_astro/*` rule; redundant with `vercel.json`).

### README changes
- Removed the `![Netlify Status]` deploy badge at the top.
- Updated the env-var intro line to reference the Vercel deploy environment instead of Netlify.
- Tech stack bullet: `Netlify` → `Vercel`.

### Netlify reference audit

| Location | Type | Action |
| --- | --- | --- |
| `netlify.toml` | config | Removed |
| `public/_headers` | config | Removed |
| `README.md` | badge + prose (3 hits) | Updated |
| `src/components/ui/Form.astro` | runtime: Netlify Forms attrs (`data-netlify`, `data-netlify-recaptcha`, `netlify-honeypot`) | **Left in place** — active form integration; moving off Netlify Forms is a separate behavioural change |
| `public/decapcms/index.html` | runtime: `<script src="https://identity.netlify.com/v1/netlify-identity-widget.js">` for Decap CMS auth | **Left in place** — active Decap CMS admin UI; swapping the auth backend is a separate change |
| `package-lock.json` | transitive: `@netlify/blobs` as an optional peer of a storage lib | Left (not a direct dep) |

No `.netlify/` directory was committed. No GitHub Actions workflows mentioned Netlify — `.github/workflows/actions.yaml` only runs build/typecheck/lint matrix jobs.

### Vercel config audit

`vercel.json` contents:
\`\`\`json
{
  "cleanUrls": true,
  "trailingSlash": false,
  "headers": [
    {
      "source": "/_astro/(.*)",
      "headers": [
        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
      ]
    }
  ]
}
\`\`\`

- `astro.config.ts` has `output: 'static'` — correct setup for Vercel static hosting with zero-config auto-detection.
- No `builds`, no `functions`, no Edge Functions config, no legacy fields.
- The three settings present (`cleanUrls`, `trailingSlash: false`, `/_astro/*` cache-control header) are all sensible for an Astro static site. `cleanUrls: true` is redundant with Vercel's auto-detected Astro output in most cases but is harmless and explicit — left as-is.

`.vercel/project.json`:
- Not committed in this branch. Not listed in `.gitignore` either — if you run `vercel link` locally it'll drop a `.vercel/` directory that will show up as untracked. See follow-ups.

### Local verification

- `npm ci` — clean
- `npm run check` — passes (`astro check` + `eslint`)
- `npm run build` — fails at Contentful SDK init (`Expected parameter accessToken`) because no env vars locally. **Expected**; CI has the secrets. Not a blocker for this PR.

### Follow-ups (not in this PR)

- [ ] Migrate `src/components/ui/Form.astro` off Netlify Forms — the contact form currently relies on Netlify-specific attributes (`data-netlify`, `data-netlify-recaptcha`, `netlify-honeypot`) and posts to `/success`. On Vercel this will 404 silently; need a replacement (Formspree, a Vercel Function, or a third-party handler).
- [ ] Replace Netlify Identity in `public/decapcms/index.html` — Decap CMS is configured to auth via Netlify Identity. Needs swap to a Git-based backend that works without Netlify Identity (e.g. GitHub OAuth proxy) or the admin UI should be deleted if unused.
- [ ] Add `.vercel/` to `.gitignore` to avoid accidentally committing `.vercel/project.json` after a local `vercel link`. Skipping here per the task brief (gitignore changes can have surprising ripple).
- [ ] Optionally drop `cleanUrls: true` from `vercel.json` — Vercel auto-detects Astro and applies equivalent behaviour. Not broken, so not removed here.

---

## :warning: DNS reminder

**This PR does NOT swap DNS.** The live apex `scaleforce.agency` still resolves via Netlify. Merge this PR only **AFTER**:

1. A successful Vercel production deploy with all required env vars configured (`CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`, `CONTENTFUL_PREVIEW_TOKEN`, `AIRTABLE_API_KEY`, `AIRTABLE_BASE_ID`).
2. `scaleforce.agency` and `www.scaleforce.agency` are attached to the Vercel project and DNS is cut over.

The Netlify site can be decommissioned after DNS propagation is confirmed.

## Test plan

- [ ] CI green on this PR (build matrix, typecheck, lint, and the Vercel preview check)
- [ ] Verify Vercel preview URL renders correctly, including `/_astro/*` long-cache headers
- [ ] Confirm the contact form behaviour on the preview (expected to break — see follow-ups above)
- [ ] Verify Decap CMS admin page at `/decapcms/` on the preview (expected to break auth — see follow-ups above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)