### PR TITLE
chore: fix LICENSE casing (ScaleForce)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2023 onWidget
-Copyright (c) 2026 Scaleforce
+Copyright (c) 2026 ScaleForce
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
Corrects `Scaleforce` → `ScaleForce` in LICENSE.md. Canonical brand casing across the repo is camelCase (`ScaleForce`).

Retroactively addresses a Copilot review thread on already-merged PR #54.

## Evidence (canonical casing across repo)
- `src/config.yaml`: `name: ScaleForce`, `site: https://ScaleForce.agency`, `site_name: ScaleForce`
- `README.md` title: `ScaleForce.agency Landing and Lead Generation Site`
- Footer: `Made by ScaleForce`
- Blog post authors (5 posts): `author: ScaleForce`
- Email: `info@ScaleForce.agency`
- Calendly: `calendly.com/ScaleForce-agency`
- GitHub org: `ScaleForceAgency`

Lowercase variants only appear in URL/technical contexts (npm pkg name, LinkedIn slug, GitHub repo slug).

## Test plan
- [x] Single-line markdown change; no functional impact
- [ ] CI green