### PR TITLE
fix(og): load fonts from @fontsource/* instead of fetching at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,3 @@ pnpm-lock.yaml
 
 .astro
 scaleforce-agency-landing.code-workspace
-
-# OG image generator font cache — repopulated on first build:og run.
-scripts/.fonts-cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
         "@astrojs/mdx": "^4.3.14",
         "@astrojs/partytown": "^2.1.7",
         "@eslint/js": "^9.10.0",
+        "@fontsource/inter-tight": "^5.2.7",
+        "@fontsource/space-grotesk": "^5.2.10",
         "@iconify-json/flat-color-icons": "^1.2.0",
         "@iconify-json/tabler": "^1.2.3",
         "@tailwindcss/typography": "^0.5.19",
@@ -1228,6 +1230,26 @@
       "version": "5.2.10",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.2.10.tgz",
       "integrity": "sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/inter-tight": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter-tight/-/inter-tight-5.2.7.tgz",
+      "integrity": "sha512-44TmSfHdNQus/3MWOMIonUEnbxwQhiaFo2sfBJEGIE4c7TN+GO6kfLzsTH4Nu52BC9HDZFl9fPQ6Cwzp9vYTtQ==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==",
+      "dev": true,
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@astrojs/mdx": "^4.3.14",
     "@astrojs/partytown": "^2.1.7",
     "@eslint/js": "^9.10.0",
+    "@fontsource/inter-tight": "^5.2.7",
+    "@fontsource/space-grotesk": "^5.2.10",
     "@iconify-json/flat-color-icons": "^1.2.0",
     "@iconify-json/tabler": "^1.2.3",
     "@tailwindcss/typography": "^0.5.19",

--- a/scripts/build-og.mjs
+++ b/scripts/build-og.mjs
@@ -6,25 +6,25 @@
  * there's no runtime token source this script can read). Runs via
  * `npm run build:og` (and the `prebuild` npm hook).
  *
- * Fonts are fetched from Google Fonts on cache miss and stored under
- * scripts/.fonts-cache/ (gitignored). Builds require network access when
- * that cache is absent — including CI and Vercel, since the workflow
- * doesn't currently cache scripts/.fonts-cache separately.
- *
- * Eliminating the build-time network fetch (load TTFs from an npm-shipped
- * package, or add explicit CI caching) is tracked as a follow-up.
+ * Fonts are loaded from the `@fontsource/*` npm packages in devDependencies
+ * (Space Grotesk 700, Inter Tight 500 — both latin WOFF). No network is
+ * touched at build time. Satori accepts WOFF directly; WOFF2 is not
+ * supported by Satori, which is why we resolve the `.woff` file rather
+ * than `.woff2`.
  */
-import { mkdir, readFile, writeFile, access } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import satori from 'satori';
 import { Resvg } from '@resvg/resvg-js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
-const FONT_CACHE = resolve(__dirname, '.fonts-cache');
 const OUT = resolve(ROOT, 'src/assets/images/default.png');
 const LOGO_SRC = resolve(ROOT, 'src/assets/favicons/apple-touch-icon.png');
+
+const require = createRequire(import.meta.url);
 
 // Brand tokens — keep in sync with src/components/CustomStyles.astro.
 const BG = '#0A0F1F';
@@ -35,32 +35,15 @@ const MUTED = 'rgba(226, 232, 243, 0.66)';
 const FONTS = [
   {
     name: 'Space Grotesk',
-    file: 'space-grotesk-700.ttf',
-    url: 'https://fonts.gstatic.com/s/spacegrotesk/v22/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj4PVksj.ttf',
+    path: require.resolve('@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff'),
     weight: 700,
   },
   {
     name: 'Inter Tight',
-    file: 'inter-tight-500.ttf',
-    url: 'https://fonts.gstatic.com/s/intertight/v9/NGSnv5HMAFg6IuGlBNMjxJEL2VmU3NS7Z2mjPQ-qXA.ttf',
+    path: require.resolve('@fontsource/inter-tight/files/inter-tight-latin-500-normal.woff'),
     weight: 500,
   },
 ];
-
-async function ensureFont({ file, url }) {
-  const path = resolve(FONT_CACHE, file);
-  try {
-    await access(path);
-  } catch {
-    await mkdir(FONT_CACHE, { recursive: true });
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`Failed to fetch font ${file} from ${url}: ${res.status} ${res.statusText}`);
-    }
-    await writeFile(path, Buffer.from(await res.arrayBuffer()));
-  }
-  return readFile(path);
-}
 
 async function loadLogoDataUrl() {
   const png = await readFile(LOGO_SRC);
@@ -155,7 +138,7 @@ function template(logoDataUrl) {
 
 async function main() {
   const [fontData, logoDataUrl] = await Promise.all([
-    Promise.all(FONTS.map((font) => ensureFont(font))),
+    Promise.all(FONTS.map((font) => readFile(font.path))),
     loadLogoDataUrl(),
   ]);
 

--- a/scripts/build-og.mjs
+++ b/scripts/build-og.mjs
@@ -35,15 +35,30 @@ const MUTED = 'rgba(226, 232, 243, 0.66)';
 const FONTS = [
   {
     name: 'Space Grotesk',
-    path: require.resolve('@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff'),
+    pkg: '@fontsource/space-grotesk',
+    specifier: '@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff',
     weight: 700,
   },
   {
     name: 'Inter Tight',
-    path: require.resolve('@fontsource/inter-tight/files/inter-tight-latin-500-normal.woff'),
+    pkg: '@fontsource/inter-tight',
+    specifier: '@fontsource/inter-tight/files/inter-tight-latin-500-normal.woff',
     weight: 500,
   },
 ];
+
+function resolveFontPath(font) {
+  try {
+    return require.resolve(font.specifier);
+  } catch (err) {
+    throw new Error(
+      `Failed to resolve font file "${font.specifier}" for ${font.name}. ` +
+        `Ensure "${font.pkg}" is installed as a devDependency (run "npm ci") ` +
+        `and that the expected .woff filename has not changed in an upstream release. ` +
+        `Underlying error: ${err.message}`
+    );
+  }
+}
 
 async function loadLogoDataUrl() {
   const png = await readFile(LOGO_SRC);
@@ -137,8 +152,9 @@ function template(logoDataUrl) {
 }
 
 async function main() {
+  const fontPaths = FONTS.map(resolveFontPath);
   const [fontData, logoDataUrl] = await Promise.all([
-    Promise.all(FONTS.map((font) => readFile(font.path))),
+    Promise.all(fontPaths.map((path) => readFile(path))),
     loadLogoDataUrl(),
   ]);
 


### PR DESCRIPTION
## Summary
- Refactors `scripts/build-og.mjs` to load Space Grotesk 700 and Inter Tight 500 from `@fontsource/*` packages in `node_modules` via `createRequire`, instead of fetching from `fonts.gstatic.com` at build time.
- Adds `@fontsource/space-grotesk` and `@fontsource/inter-tight` to devDependencies. Satori supports WOFF directly, so no TTF conversion is needed (WOFF2 is not supported by Satori, which is why we resolve the `.woff` variants).
- Removes the `scripts/.fonts-cache/` `.gitignore` entry — nothing writes to it anymore.

Closes #68.

## Why
CI, Vercel, and offline builds no longer depend on Google Fonts reachability. First-run builds on a clean cache used to require network; now `npm ci && npm run build:og` works fully offline.

## Test plan
- [x] `npm run build:og` writes `src/assets/images/default.png` (73070 bytes) with no network
- [x] `npm run check:astro` green
- [ ] Reviewer: confirm OG image renders visually unchanged (no font-fallback artifacts) before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)