### PR TITLE
feat(blog): unify author attribution across all three blog sources

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,5 @@
 # TODO
 
-## Author attribution (syndicated posts)
-
-The `thomhayner` loader (`src/lib/thomhayner/thomhayner.ts`) currently hardcodes
-`author: "Thom Hayner"` because `Post.author` is a plain string. Next step is a
-richer author model:
-
-- Introduce an `author` content type in Contentful — or a static map in
-  `src/config.yaml` — with `name`, `avatarUrl`, `bio`, `personalSite`.
-- Resolve `post.author` to that entry in `src/utils/blog.ts`.
-- Update `src/components/blog/SinglePost.astro` to render an author block
-  (avatar + bio + link to personal site) when the author resolves.
-
-Until then, every syndicated post's byline simply reads "Thom Hayner".
-
 ## Brand identity follow-ups (Phase 7 Wave 4+)
 
 Deferred from Wave 3 ([docs/brand/guidelines.md](docs/brand/guidelines.md)):

--- a/docs/adr/ADR-2026-04-22-author-attribution-model.md
+++ b/docs/adr/ADR-2026-04-22-author-attribution-model.md
@@ -47,11 +47,18 @@ when `authorRef` is present, and falls back to the plain string slug
 otherwise. The compact date-row byline prefers `authorRef.name` and
 falls back to the slug.
 
-The initial seed has two entries:
+The initial Contentful seed:
 
-- `scaleforce` (organization) — avatar points to the repo logo.
-- `thom-hayner` (person) — avatar points to a selfie, `personalSite`
-  set to `https://thomhayner.com`.
+- `scaleforce` (organization) — published with the repo logo as avatar.
+- `thom-hayner` (person) — **deferred follow-up in this PR.** The
+  selfie intended as the avatar wasn't persisted to disk during the
+  authoring session, so the asset upload + entry creation couldn't
+  complete. Until that entry exists, syndicated thomhayner.com posts
+  byline as the literal slug `thom-hayner` (the resolver returns
+  `undefined` for an unknown slug and the UI falls back to the plain
+  string). Target entry shape: name="Thom Hayner", type="person",
+  avatar=selfie, bio="AI Solution Engineer",
+  personalSite="https://thomhayner.com".
 
 ## Alternatives considered
 

--- a/docs/adr/ADR-2026-04-22-author-attribution-model.md
+++ b/docs/adr/ADR-2026-04-22-author-attribution-model.md
@@ -1,0 +1,113 @@
+---
+id: ADR-2026-04-22-author-attribution-model
+title: Unify author attribution across blog sources via Contentful `author` content type
+status: accepted
+date: 2026-04-22
+deciders: [thomHayner]
+tags: [contentful, blog, content-model]
+supersedes: []
+superseded_by: []
+related: [ADR-2026-04-21-multi-source-blog-architecture]
+source: claude-code-session-2026-04-22
+---
+
+## Context
+
+The blog aggregates posts from three sources: local markdown
+(`src/content/post/`), Contentful case studies (a future `useCasePost`
+content type — not yet defined; the code path is dead today), and
+syndicated posts from [thomhayner.com](https://thomhayner.com) pulled
+over the GitHub API.
+
+All three normalize to a common `Post` shape in `src/utils/blog.ts`,
+but `Post.author` was a plain string. That forced two bad compromises:
+
+1. Local posts had `author: ScaleForce` — a brand name used as an
+   identifier, which reads fine on the byline but can't carry a bio,
+   avatar, or link.
+2. The `thomhayner` loader hard-coded `author: 'Thom Hayner'` with a
+   TODO explaining the same limitation.
+
+We needed a single place to store author metadata that every source
+could reference by slug, without duplicating per-source author fields
+or inventing a static YAML map that would diverge from Contentful.
+
+## Decision
+
+Introduce a Contentful `author` content type and treat `Post.author`
+as a **slug reference** (e.g. `scaleforce`, `thom-hayner`) across all
+three sources. A new resolver in `src/lib/authors/authors.ts` fetches
+and caches all author entries, exposing `getAuthorBySlug(slug)`.
+`src/utils/blog.ts` calls the resolver in each of the three normalize
+functions and attaches the result as `Post.authorRef`.
+
+`SinglePost.astro` renders a rich byline block (rounded avatar +
+name + bio + optional `personalSite` link when `type === 'person'`)
+when `authorRef` is present, and falls back to the plain string slug
+otherwise. The compact date-row byline prefers `authorRef.name` and
+falls back to the slug.
+
+The initial seed has two entries:
+
+- `scaleforce` (organization) — avatar points to the repo logo.
+- `thom-hayner` (person) — avatar points to a selfie, `personalSite`
+  set to `https://thomhayner.com`.
+
+## Alternatives considered
+
+- **Static `src/config.yaml` author map.** Simpler, no extra fetch,
+  no extra Contentful content type to maintain. Rejected because
+  authors (especially the ScaleForce brand voice and avatar) change
+  more like content than like configuration, and because the
+  multi-source blog already depends on Contentful for the case-study
+  track — adding a second system of record for author metadata would
+  fragment the content model.
+- **Per-source author fields** (richer frontmatter on local posts,
+  a nested author object on the Contentful `useCasePost` type, a
+  separate loader-level map for syndicated posts). Rejected — that's
+  three places to update whenever an author's bio, avatar, or site
+  changes. The whole point of unifying the three sources is to avoid
+  that.
+- **Render `socialLinks` in the byline now.** Rejected for this PR
+  per design input: `personalSite` already covers attribution for
+  Thom, and the one author who has a `personalSite` doesn't have
+  separate social links to render. The `socialLinks` field is defined
+  on the content type so a future UI change can use it without a
+  schema migration, but no byline UI reads it yet.
+
+## Consequences
+
+- **Positive:** Single source of truth for author metadata. All three
+  blog sources render consistent bylines. Changing Thom's bio or
+  avatar is a Contentful edit, not a code change or a frontmatter
+  sweep.
+- **Positive:** Adding a new author (e.g. a guest contributor) is an
+  entry creation + slug reference on the post — no schema change.
+- **Negative:** Build-time dependency on Contentful for author
+  resolution. The resolver degrades gracefully (logs and returns
+  `undefined`), so an outage shows the string slug, not an error.
+- **Negative:** Author entries and asset uploads live in Contentful,
+  not git. Changes are outside the PR flow — treat the Contentful
+  entries and the code references as coupled, and remember to update
+  Contentful when introducing a new slug.
+- **Follow-ups:**
+  - Wire `Post.authorRef` into author-archive routes (list a specific
+    author's posts) if/when we start producing multi-author content.
+  - Render `socialLinks` once a second non-personal-site link (X,
+    GitHub, etc.) is worth surfacing.
+  - When the `useCasePost` content type is eventually defined in
+    Contentful, wire its `author` field to the same slug convention
+    (the `UseCasePost` TS declaration in `src/lib/contentful/contentful.ts`
+    already types `author` as a text slug).
+
+## Notes
+
+- The rounded-avatar decision was explicit user input; the byline
+  block renders both `person` and `organization` types with the
+  same rounded avatar shape for visual consistency.
+- The resolver caches authors for the lifetime of the Astro build
+  (`_cache` in `authors.ts`) — one Contentful fetch per build, not
+  per post.
+- The `thomhayner.ts` loader no longer carries a TODO block; the
+  `TODO.md` "Author attribution (syndicated posts)" section is
+  removed in this PR.

--- a/src/components/blog/ListItem.astro
+++ b/src/components/blog/ListItem.astro
@@ -67,11 +67,11 @@ const link = APP_BLOG?.post?.isEnabled ? getPermalink(post.permalink, 'post') : 
           <Icon name="tabler:clock" class="w-3.5 h-3.5 inline-block -mt-0.5 dark:text-gray-400" />
           <time datetime={String(post.publishDate)} class="inline-block">{getFormattedDate(post.publishDate)}</time>
           {
-            post.author && (
+            (post.authorRef?.name || post.author) && (
               <>
                 {' '}
                 · <Icon name="tabler:user" class="w-3.5 h-3.5 inline-block -mt-0.5 dark:text-gray-400" />
-                <span>{post.author.replaceAll('-', ' ')}</span>
+                <span>{post.authorRef?.name ?? post.author?.replaceAll('-', ' ')}</span>
               </>
             )
           }

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -26,11 +26,11 @@ const { post, url } = Astro.props;
           <Icon name="tabler:clock" class="w-4 h-4 inline-block -mt-0.5 dark:text-gray-400" />
           <time datetime={String(post.publishDate)} class="inline-block">{getFormattedDate(post.publishDate)}</time>
           {
-            post.author && (
+            (post.authorRef?.name || post.author) && (
               <>
                 {' '}
                 · <Icon name="tabler:user" class="w-4 h-4 inline-block -mt-0.5 dark:text-gray-400" />
-                <span class="inline-block">{post.author}</span>
+                <span class="inline-block">{post.authorRef?.name ?? post.author}</span>
               </>
             )
           }
@@ -65,6 +65,40 @@ const { post, url } = Astro.props;
       >
         {post.excerpt}
       </p>
+
+      {
+        post.authorRef && (
+          <div class="max-w-3xl mx-auto mt-4 mb-8 px-4 sm:px-6 flex items-center gap-4">
+            {post.authorRef.avatarUrl && (
+              <img
+                src={post.authorRef.avatarUrl}
+                alt={post.authorRef.name}
+                width={56}
+                height={56}
+                loading="lazy"
+                decoding="async"
+                class="w-14 h-14 rounded-full object-cover bg-gray-100 dark:bg-slate-700"
+              />
+            )}
+            <div class="flex flex-col">
+              <span class="font-semibold text-default">{post.authorRef.name}</span>
+              {post.authorRef.bio && (
+                <span class="text-sm text-muted dark:text-slate-400">{post.authorRef.bio}</span>
+              )}
+              {post.authorRef.type === 'person' && post.authorRef.personalSite && (
+                <a
+                  href={post.authorRef.personalSite}
+                  class="text-sm text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {post.authorRef.personalSite.replace(/^https?:\/\//, '').replace(/\/$/, '')}
+                </a>
+              )}
+            </div>
+          </div>
+        )
+      }
 
       {
         post.image ? (

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -16,6 +16,21 @@ export interface Props {
 }
 
 const { post, url } = Astro.props;
+
+// Validate `personalSite` before rendering — the URL comes from a CMS field so
+// we guard against non-http(s) protocols (`javascript:`, `data:`) and malformed
+// URLs rather than dropping the raw string into an `href`.
+const personalSiteHref = (() => {
+  const raw = post.authorRef?.type === 'person' ? post.authorRef.personalSite : undefined;
+  if (!raw) return undefined;
+  try {
+    const u = new URL(raw);
+    if (!['http:', 'https:'].includes(u.protocol)) return undefined;
+    return u.toString();
+  } catch {
+    return undefined;
+  }
+})();
 ---
 
 <section class="py-8 sm:py-16 lg:py-20 mx-auto">
@@ -85,14 +100,14 @@ const { post, url } = Astro.props;
               {post.authorRef.bio && (
                 <span class="text-sm text-muted dark:text-slate-400">{post.authorRef.bio}</span>
               )}
-              {post.authorRef.type === 'person' && post.authorRef.personalSite && (
+              {personalSiteHref && (
                 <a
-                  href={post.authorRef.personalSite}
+                  href={personalSiteHref}
                   class="text-sm text-primary hover:underline"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {post.authorRef.personalSite.replace(/^https?:\/\//, '').replace(/\/$/, '')}
+                  {personalSiteHref.replace(/^https?:\/\//, '').replace(/\/$/, '')}
                 </a>
               )}
             </div>

--- a/src/content/post/ai-agents-to-reduce-employee-turnover-1.md
+++ b/src/content/post/ai-agents-to-reduce-employee-turnover-1.md
@@ -7,7 +7,7 @@ category: Resources
 tags:
   - AI agents
   - AI assistants
-author: ScaleForce
+author: scaleforce
 ---
 
 ## Overview of AI to Reduce Employee Turnover

--- a/src/content/post/ai-agents-to-reduce-employee-turnover-2.md
+++ b/src/content/post/ai-agents-to-reduce-employee-turnover-2.md
@@ -7,7 +7,7 @@ category: Resources
 tags:
   - AI agents
   - AI assistants
-author: ScaleForce
+author: scaleforce
 ---
 
 ## Overview of AI to Reduce Employee Turnover

--- a/src/content/post/ai-assistants-vs-ai-agents.md
+++ b/src/content/post/ai-assistants-vs-ai-agents.md
@@ -7,7 +7,7 @@ category: Resources
 tags:
   - AI Assistants
   - AI Agents
-author: ScaleForce
+author: scaleforce
 ---
 
 ## Artificial Intelligence: A Brief Overview

--- a/src/content/post/types-of-ai-agents.md
+++ b/src/content/post/types-of-ai-agents.md
@@ -6,7 +6,7 @@ image: https://images.unsplash.com/photo-1620712943543-bcc4688e7485?q=80&w=2765&
 category: Resources
 tags:
   - AI Agents
-author: ScaleForce
+author: scaleforce
 ---
 
 ## Overview of AI Agents

--- a/src/content/post/types-of-ai-assistants.md
+++ b/src/content/post/types-of-ai-assistants.md
@@ -6,7 +6,7 @@ image: https://images.unsplash.com/photo-1530545002211-21753020f4c8?q=80&w=2809&
 category: Resources
 tags:
   - AI Assistants
-author: ScaleForce
+author: scaleforce
 ---
 
 ## Overview of AI Assistants

--- a/src/lib/authors/authors.ts
+++ b/src/lib/authors/authors.ts
@@ -1,0 +1,92 @@
+// Resolves author frontmatter slugs (e.g. `scaleforce`, `thom-hayner`) into rich author
+// metadata stored as the `author` content type in Contentful.
+//
+// Posts from all three sources (local markdown, Contentful case studies, thomhayner.com
+// syndicated) use the same slug convention, so this resolver is the single source of
+// truth for bylines.
+
+import contentful from 'contentful';
+import type { Asset, Entry, EntryFieldTypes } from 'contentful';
+
+export interface Author {
+  slug: string;
+  name: string;
+  type: 'person' | 'organization';
+  avatarUrl?: string;
+  bio?: string;
+  personalSite?: string;
+  socialLinks?: Record<string, string>;
+}
+
+interface AuthorFields {
+  contentTypeId: 'author';
+  fields: {
+    name: EntryFieldTypes.Symbol;
+    slug: EntryFieldTypes.Symbol;
+    type: EntryFieldTypes.Symbol;
+    avatar?: Asset;
+    bio?: EntryFieldTypes.Text;
+    personalSite?: EntryFieldTypes.Symbol;
+    socialLinks?: EntryFieldTypes.Object<Record<string, string>>;
+  };
+}
+
+const authorsClient = contentful.createClient({
+  space: import.meta.env.CONTENTFUL_SPACE_ID,
+  accessToken: import.meta.env.DEV
+    ? import.meta.env.CONTENTFUL_PREVIEW_TOKEN
+    : import.meta.env.CONTENTFUL_DELIVERY_TOKEN,
+  host: import.meta.env.DEV ? 'preview.contentful.com' : 'cdn.contentful.com',
+});
+
+const normalizeAssetUrl = (url?: string): string | undefined => {
+  if (!url) return undefined;
+  if (url.startsWith('//')) return `https:${url}`;
+  return url;
+};
+
+const toAuthor = (entry: Entry<AuthorFields>): Author => {
+  const f = entry.fields;
+  const avatarFile = (f.avatar as Asset | undefined)?.fields?.file;
+  const avatarUrl = typeof avatarFile?.url === 'string' ? normalizeAssetUrl(avatarFile.url) : undefined;
+
+  return {
+    slug: f.slug as string,
+    name: f.name as string,
+    type: (f.type as 'person' | 'organization') ?? 'organization',
+    avatarUrl,
+    bio: (f.bio as string | undefined) || undefined,
+    personalSite: (f.personalSite as string | undefined) || undefined,
+    socialLinks: (f.socialLinks as Record<string, string> | undefined) || undefined,
+  };
+};
+
+let _cache: Map<string, Author> | null = null;
+
+const loadAuthors = async (): Promise<Map<string, Author>> => {
+  if (_cache) return _cache;
+
+  const map = new Map<string, Author>();
+  try {
+    const res = await authorsClient.getEntries<AuthorFields>({
+      content_type: 'author',
+      include: 1,
+      limit: 200,
+    });
+    for (const entry of res.items) {
+      const author = toAuthor(entry);
+      if (author.slug) map.set(author.slug, author);
+    }
+  } catch (err) {
+    console.warn('[authors loader] failed to fetch authors from Contentful:', err);
+  }
+
+  _cache = map;
+  return _cache;
+};
+
+export const getAuthorBySlug = async (slug: string | undefined): Promise<Author | undefined> => {
+  if (!slug) return undefined;
+  const authors = await loadAuthors();
+  return authors.get(slug);
+};

--- a/src/lib/authors/authors.ts
+++ b/src/lib/authors/authors.ts
@@ -5,8 +5,8 @@
 // syndicated) use the same slug convention, so this resolver is the single source of
 // truth for bylines.
 
-import contentful from 'contentful';
 import type { Asset, Entry, EntryFieldTypes } from 'contentful';
+import { contentfulClient } from '../contentful/contentful';
 
 export interface Author {
   slug: string;
@@ -31,19 +31,19 @@ interface AuthorFields {
   };
 }
 
-const authorsClient = contentful.createClient({
-  space: import.meta.env.CONTENTFUL_SPACE_ID,
-  accessToken: import.meta.env.DEV
-    ? import.meta.env.CONTENTFUL_PREVIEW_TOKEN
-    : import.meta.env.CONTENTFUL_DELIVERY_TOKEN,
-  host: import.meta.env.DEV ? 'preview.contentful.com' : 'cdn.contentful.com',
-});
-
 const normalizeAssetUrl = (url?: string): string | undefined => {
   if (!url) return undefined;
   if (url.startsWith('//')) return `https:${url}`;
   return url;
 };
+
+const AUTHOR_TYPES = ['person', 'organization'] as const;
+type AuthorType = (typeof AUTHOR_TYPES)[number];
+
+const coerceAuthorType = (raw: unknown): AuthorType =>
+  typeof raw === 'string' && (AUTHOR_TYPES as readonly string[]).includes(raw)
+    ? (raw as AuthorType)
+    : 'organization';
 
 const toAuthor = (entry: Entry<AuthorFields>): Author => {
   const f = entry.fields;
@@ -53,7 +53,7 @@ const toAuthor = (entry: Entry<AuthorFields>): Author => {
   return {
     slug: f.slug as string,
     name: f.name as string,
-    type: (f.type as 'person' | 'organization') ?? 'organization',
+    type: coerceAuthorType(f.type),
     avatarUrl,
     bio: (f.bio as string | undefined) || undefined,
     personalSite: (f.personalSite as string | undefined) || undefined,
@@ -61,28 +61,49 @@ const toAuthor = (entry: Entry<AuthorFields>): Author => {
   };
 };
 
+// Cache state:
+// - `_cache` is only set on a successful fetch — a transient Contentful outage won't
+//   permanently degrade author resolution for the lifetime of the process.
+// - `_cachePromise` memoizes the in-flight request so parallel callers (e.g. the three
+//   normalize functions running under `Promise.all` in `src/utils/blog.ts`) share one
+//   Contentful round-trip per build / dev-server session instead of one-per-post.
 let _cache: Map<string, Author> | null = null;
+let _cachePromise: Promise<Map<string, Author>> | null = null;
+
+const fetchAuthors = async (): Promise<Map<string, Author>> => {
+  const map = new Map<string, Author>();
+  const res = await contentfulClient.getEntries<AuthorFields>({
+    content_type: 'author',
+    include: 1,
+    limit: 200,
+  });
+  for (const entry of res.items) {
+    const author = toAuthor(entry);
+    if (author.slug) map.set(author.slug, author);
+  }
+  return map;
+};
 
 const loadAuthors = async (): Promise<Map<string, Author>> => {
   if (_cache) return _cache;
+  if (_cachePromise) return _cachePromise;
 
-  const map = new Map<string, Author>();
-  try {
-    const res = await authorsClient.getEntries<AuthorFields>({
-      content_type: 'author',
-      include: 1,
-      limit: 200,
+  _cachePromise = fetchAuthors()
+    .then((map) => {
+      _cache = map;
+      return map;
+    })
+    .catch((err) => {
+      console.warn('[authors loader] failed to fetch authors from Contentful:', err);
+      // Intentionally do NOT populate `_cache` on failure — return an empty map for
+      // this caller but let the next call retry the fetch.
+      return new Map<string, Author>();
+    })
+    .finally(() => {
+      _cachePromise = null;
     });
-    for (const entry of res.items) {
-      const author = toAuthor(entry);
-      if (author.slug) map.set(author.slug, author);
-    }
-  } catch (err) {
-    console.warn('[authors loader] failed to fetch authors from Contentful:', err);
-  }
 
-  _cache = map;
-  return _cache;
+  return _cachePromise;
 };
 
 export const getAuthorBySlug = async (slug: string | undefined): Promise<Author | undefined> => {

--- a/src/lib/thomhayner/thomhayner.ts
+++ b/src/lib/thomhayner/thomhayner.ts
@@ -1,10 +1,5 @@
 // Loads syndicated blog posts from https://github.com/thomHayner/thomHayner.com.
 // Filters to posts whose frontmatter opts in via `crossPostTo: ['scaleforce']`.
-//
-// TODO(author-attribution): scaleforce's Post schema currently has `author: string` only.
-// When we introduce an `author` content type (Contentful) or a static map in
-// `src/config.yaml` with name/avatar/bio/site, wire the byline + SinglePost.astro to
-// resolve `post.author` into a richer block. For now we hardcode `author: "Thom Hayner"`.
 
 import matter from 'gray-matter';
 import { remark } from 'remark';
@@ -140,7 +135,7 @@ const buildPost = async (
       image,
       category,
       tags,
-      author: 'Thom Hayner',
+      author: 'thom-hayner',
       metadata: {
         canonical,
         ...(image && fm.heroImageAlt

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,7 @@
 import type { AstroComponentFactory } from 'astro/runtime/server/index.js';
 import type { HTMLAttributes, ImageMetadata } from 'astro/types';
 import type { Asset, RichText } from 'contentful';
+import type { Author } from '~/lib/authors/authors';
 
 export interface FormattedContentfulPost {
   id: string,
@@ -51,8 +52,10 @@ export interface Post {
   category?: Taxonomy;
   /**  */
   tags?: Taxonomy[];
-  /**  */
+  /** Slug reference matching the Contentful `author` content type (e.g. `scaleforce`, `thom-hayner`). */
   author?: string;
+  /** Resolved author metadata, populated at normalization time from the Contentful `author` content type. */
+  authorRef?: Author;
 
   /**  */
   metadata?: MetaData;

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -12,6 +12,8 @@ import { documentToHtmlString } from "@contentful/rich-text-html-renderer";
 import { loadThomhaynerPosts } from "../lib/thomhayner/thomhayner";
 import type { FormattedThomhaynerPost } from "../lib/thomhayner/thomhayner";
 
+import { getAuthorBySlug } from "../lib/authors/authors";
+
 const generatePermalink = async ({
   id,
   slug,
@@ -85,6 +87,8 @@ const getNormalizedPost = async (post: CollectionEntry<'post'>): Promise<Post> =
     title: tag,
   }));
 
+  const authorRef = await getAuthorBySlug(author);
+
   return {
     id: id,
     slug: slug,
@@ -101,6 +105,7 @@ const getNormalizedPost = async (post: CollectionEntry<'post'>): Promise<Post> =
     category: category,
     tags: tags,
     author: author,
+    authorRef: authorRef,
 
     metadata,
 
@@ -146,6 +151,8 @@ const getNormalizedContentfulPost = async (post: FormattedContentfulPost): Promi
     title: tag,
   }));
 
+  const authorRef = await getAuthorBySlug(author);
+
   return {
     id: id,
     slug: slug,
@@ -162,6 +169,7 @@ const getNormalizedContentfulPost = async (post: FormattedContentfulPost): Promi
     category: category,
     tags: tags,
     author: author,
+    authorRef: authorRef,
 
     metadata,
 
@@ -203,6 +211,8 @@ const getNormalizedThomhaynerPost = async (post: FormattedThomhaynerPost): Promi
     title: tag,
   }));
 
+  const authorRef = await getAuthorBySlug(author);
+
   return {
     id: id,
     slug: slug,
@@ -219,6 +229,7 @@ const getNormalizedThomhaynerPost = async (post: FormattedThomhaynerPost): Promi
     category: category,
     tags: tags,
     author: author,
+    authorRef: authorRef,
 
     metadata,
 


### PR DESCRIPTION
## Summary

Introduces a Contentful `author` content type + a `getAuthorBySlug` resolver so local, Contentful, and thomhayner.com-syndicated posts all render consistent bylines (rounded avatar, name, bio, optional personal-site link) driven by a single `author: <slug>` frontmatter reference.

See [docs/adr/ADR-2026-04-22-author-attribution-model.md](docs/adr/ADR-2026-04-22-author-attribution-model.md) for context, alternatives, and follow-ups.

## Contentful side (already done)

- `author` content type published: fields `name`, `slug` (unique), `type` (`person`|`organization`), `avatar` (→Asset), `bio`, `personalSite`, `socialLinks` (Object, not rendered in UI yet).
- `scaleforce` (organization) entry published with the repo logo as the avatar.
- **`thom-hayner` (person) entry is a deferred follow-up** — the avatar selfie wasn't persisted to disk during the session so it couldn't be uploaded as an asset. Until that entry exists, Thom-syndicated posts will byline as the literal slug `thom-hayner`.

## Code changes

- `src/content/post/*.md` (×5): `author: ScaleForce` → `author: scaleforce`
- `src/lib/thomhayner/thomhayner.ts`: hardcode `'Thom Hayner'` → `'thom-hayner'`; remove the stale author-attribution TODO block
- `src/lib/authors/authors.ts` (new): `Author` interface + in-memory-cached `getAuthorBySlug`
- `src/utils/blog.ts`: resolver wired into all three normalize functions
- `src/types.d.ts`: `Post.authorRef?: Author`
- `src/components/blog/SinglePost.astro`: rich byline block (rounded avatar + name + bio + personalSite link for \`type === 'person'\`); date row byline prefers \`authorRef.name\` and falls back to slug
- `TODO.md`: removed the "Author attribution (syndicated posts)" block (superseded by the ADR)

## Test plan

- [x] \`npm run check\` — \`astro check\` clean (0 errors, 0 warnings) and ESLint clean
- [ ] Visual spot-check of a local post byline (ScaleForce avatar rounds, bio reads correctly)
- [ ] Visual spot-check of a thomhayner-syndicated post byline once the \`thom-hayner\` Contentful entry is seeded
- [ ] Verify CI build on Vercel (local sandbox build couldn't reach \`cdn.contentful.com\`, unrelated to this PR)

## Follow-ups

- [ ] Upload Thom's selfie to Contentful as an asset, seed + publish \`thom-hayner\` entry
- [ ] Render \`socialLinks\` in the byline once there's a second link worth showing

🤖 Generated with [Claude Code](https://claude.com/claude-code)