### PR TITLE
fix(header): bump desktop nav breakpoint from md to lg

### DIFF
--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -7,7 +7,7 @@ import { SITE } from 'site:config';
 ---
 
 <span
-  class="flex self-center ml-2 rtl:ml-0 rtl:mr-2 text-2xl md:text-xl font-bold text-gray-900 whitespace-nowrap dark:text-white"
+  class="flex self-center ml-2 rtl:ml-0 rtl:mr-2 text-2xl lg:text-xl font-bold text-gray-900 whitespace-nowrap dark:text-white"
 >
   <Image
     src={logo}

--- a/src/components/common/BasicScripts.astro
+++ b/src/components/common/BasicScripts.astro
@@ -105,7 +105,7 @@ import { UI } from 'site:config';
       newlink.click();
     });
 
-    const screenSize = window.matchMedia('(max-width: 767px)');
+    const screenSize = window.matchMedia('(max-width: 1023px)');
     screenSize.addEventListener('change', function () {
       document.querySelector('[data-aw-toggle-menu]')?.classList.remove('expanded');
       document.body.classList.remove('overflow-hidden');

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -58,12 +58,12 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
   <div class="absolute inset-0"></div>
   <div
     class:list={[
-      'relative text-default py-3 px-3 md:px-6 mx-auto w-full',
+      'relative text-default py-3 px-3 lg:px-6 mx-auto w-full',
       {
-        'md:flex md:justify-between': position !== 'center',
+        'lg:flex lg:justify-between': position !== 'center',
       },
       {
-        'md:grid md:grid-cols-3 md:items-center': position === 'center',
+        'lg:grid lg:grid-cols-3 lg:items-center': position === 'center',
       },
       {
         'max-w-7xl': !isFullWidth,
@@ -74,16 +74,16 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
       <a class="flex items-center" href={getHomePermalink()}>
         <Logo />
       </a>
-      <div class="flex items-center md:hidden">
+      <div class="flex items-center lg:hidden">
         <ToggleMenu />
       </div>
     </div>
     <nav
-      class="items-center w-full md:w-auto hidden md:flex md:mx-5 text-default overflow-y-auto overflow-x-hidden md:overflow-y-visible md:overflow-x-auto md:justify-self-center"
+      class="items-center w-full lg:w-auto hidden lg:flex lg:mx-5 text-default overflow-y-auto overflow-x-hidden lg:overflow-y-visible lg:overflow-x-auto lg:justify-self-center"
       aria-label="Main navigation"
     >
       <ul
-        class="flex flex-col md:flex-row md:self-center w-full md:w-auto text-xl md:text-[0.9375rem] tracking-[0.01rem] font-medium md:justify-center"
+        class="flex flex-col lg:flex-row lg:self-center w-full lg:w-auto text-xl lg:text-[0.9375rem] tracking-[0.01rem] font-medium lg:justify-center"
       >
         {
           links.map(({ text, href, links }) => (
@@ -95,9 +95,9 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
                     class="hover:text-link dark:hover:text-white px-4 py-3 flex items-center whitespace-nowrap"
                   >
                     {text}{' '}
-                    <Icon name="tabler:chevron-down" class="w-3.5 h-3.5 ml-0.5 rtl:ml-0 rtl:mr-0.5 hidden md:inline" />
+                    <Icon name="tabler:chevron-down" class="w-3.5 h-3.5 ml-0.5 rtl:ml-0 rtl:mr-0.5 hidden lg:inline" />
                   </button>
-                  <ul class="dropdown-menu md:backdrop-blur-md dark:md:bg-dark rounded md:absolute pl-4 md:pl-0 md:hidden font-medium md:bg-white/90 md:min-w-[200px] drop-shadow-xl">
+                  <ul class="dropdown-menu lg:backdrop-blur-md dark:lg:bg-dark rounded lg:absolute pl-4 lg:pl-0 lg:hidden font-medium lg:bg-white/90 lg:min-w-[200px] drop-shadow-xl">
                     {links.map(({ text: text2, href: href2 }) => (
                       <li>
                         <a
@@ -132,12 +132,12 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
     <div
       class:list={[
         { 'ml-auto rtl:ml-0 rtl:mr-auto': position === 'left' },
-        'hidden md:self-center md:flex items-center md:mb-0 fixed w-full md:w-auto md:static justify-end left-0 rtl:left-auto rtl:right-0 bottom-0 p-3 md:p-0 md:justify-self-end',
+        'hidden lg:self-center lg:flex items-center lg:mb-0 fixed w-full lg:w-auto lg:static justify-end left-0 rtl:left-auto rtl:right-0 bottom-0 p-3 lg:p-0 lg:justify-self-end',
       ]}
     >
-      <div class="items-center flex justify-between w-full md:w-auto">
+      <div class="items-center flex justify-between w-full lg:w-auto">
         <div class="flex">
-          {showToggleTheme && <ToggleTheme iconClass="w-6 h-6 md:w-5 md:h-5 md:inline-block" />}
+          {showToggleTheme && <ToggleTheme iconClass="w-6 h-6 lg:w-5 lg:h-5 lg:inline-block" />}
           {
             showRssFeed && (
               <a
@@ -154,7 +154,7 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
           actions?.length ? (
             <span class="ml-4 rtl:ml-0 rtl:mr-4">
               {actions.map((btnProps) => (
-                <Button {...btnProps} class="ml-2 py-2.5 px-5.5 md:px-6 font-semibold shadow-none text-sm w-auto" />
+                <Button {...btnProps} class="ml-2 py-2.5 px-5.5 lg:px-6 font-semibold shadow-none text-sm w-auto" />
               ))}
             </span>
           ) : (


### PR DESCRIPTION
## Summary

The desktop nav layout activates at `md:` (768px), but the logo + 6 nav links + theme toggle + Book-a-call CTA don't fit between 768–1024px. Result: the logo overlaps the first nav link, and the last nav link's dropdown chevron overlaps the theme toggle.

Bumps every breakpoint switch in [`Header.astro`](src/components/widgets/Header.astro) and [`Logo.astro`](src/components/Logo.astro) from `md:` → `lg:` (1024px). The mobile hamburger now stays until there's actually room for the desktop layout.

## What changed

- `src/components/widgets/Header.astro` — all layout-switching `md:` classes → `lg:` (grid, flex, padding, hidden/inline toggles, dropdown menu, theme toggle icon size, CTA padding).
- `src/components/Logo.astro` — `md:text-xl` → `lg:text-xl` so the logo text shrinks at the same breakpoint the desktop layout activates.
- `src/components/common/BasicScripts.astro` — `matchMedia('(max-width: 767px)')` → `(max-width: 1023px)` so the mobile-menu reset (clears `overflow-hidden` / `h-screen` / `expanded`) fires when crossing the new desktop boundary, not the old one. Added in round 1 of Copilot review.

## Test plan

- [ ] Resize between 320px and 1280px — hamburger should be visible up to 1023px, desktop nav at 1024px+.
- [ ] At 1024px, no overlap between logo / nav links / theme toggle / CTA.
- [ ] Mobile menu still opens and closes via the hamburger.
- [ ] Open the hamburger between 768–1023px, then resize past 1024px — page should not stay locked in the "menu open" state (no `overflow-hidden` on body, no `h-screen` on header).
- [ ] Blog dropdown opens correctly on desktop (1024px+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
