### PR TITLE
chore(analytics): remove orphaned SplitbeeAnalytics component

### DIFF
--- a/src/components/common/SplitbeeAnalytics.astro
+++ b/src/components/common/SplitbeeAnalytics.astro
@@ -1,6 +1,0 @@
----
-const { doNotTrack = true, noCookieMode = false, url = 'https://cdn.splitbee.io/sb.js' } = Astro.props;
----
-
-<!-- Splitbee Analytics -->
-<script is:inline data-respect-dnt={doNotTrack} data-no-cookie={noCookieMode} async src={url}></script>


### PR DESCRIPTION
## Summary

Follow-up cleanup from [#85](https://github.com/scaleforce/scaleforce-agency-landing/pull/85)'s analytics-removal theme. Removes `src/components/common/SplitbeeAnalytics.astro`, a pre-existing leftover from the AstroWind template that was never imported anywhere.

Verified zero importers before deletion:

```
git grep -ni splitbee
git grep -n SplitbeeAnalytics
```

Both matched only the file itself. `npm run check` (astro check + eslint) passes with 0 errors / 0 warnings.

## Test plan

- [ ] `npm ci` succeeds
- [ ] `npm run build` succeeds
- [ ] `npm run check` passes (0 errors / 0 warnings)