### PR TITLE
chore(analytics): remove dead Partytown integration + vendor AnalyticsConfig

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,10 +6,8 @@ import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import mdx from '@astrojs/mdx';
-import partytown from '@astrojs/partytown';
 import icon from 'astro-icon';
 import compress from 'astro-compress';
-import type { AstroIntegration } from 'astro';
 
 import astrowind from './vendor/integration';
 
@@ -18,10 +16,6 @@ import { readingTimeRemarkPlugin, responsiveTablesRehypePlugin, lazyImagesRehype
 // import astroAirtable from './src/lib/astro-airtable/astro-airtable';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-const hasExternalScripts = false;
-const whenExternalScripts = (items: (() => AstroIntegration) | (() => AstroIntegration)[] = []) =>
-  hasExternalScripts ? (Array.isArray(items) ? items.map((item) => item()) : [items()]) : [];
 
 // https://astro.build/config
 export default defineConfig({
@@ -36,13 +30,7 @@ export default defineConfig({
         'line-md': ['*'],
       }
     }),
-    
-    ...whenExternalScripts(() => partytown({
-      config: {
-        forward: ['dataLayer.push']
-      }
-    })),
-    
+
     compress({
       CSS: true,
       HTML: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
         "@astrojs/mdx": "^4.3.14",
-        "@astrojs/partytown": "^2.1.7",
         "@eslint/js": "^9.10.0",
         "@fontsource/inter-tight": "^5.2.7",
         "@fontsource/space-grotesk": "^5.2.10",
@@ -363,15 +362,6 @@
       },
       "peerDependencies": {
         "astro": "^5.0.0"
-      }
-    },
-    "node_modules/@astrojs/partytown": {
-      "version": "2.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@qwik.dev/partytown": "^0.13.2",
-        "mrmime": "^2.0.1"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -2167,20 +2157,6 @@
         "@types/node": "*",
         "deepmerge-ts": "7.1.5",
         "fast-glob": "3.3.3"
-      }
-    },
-    "node_modules/@qwik.dev/partytown": {
-      "version": "0.13.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.4.7"
-      },
-      "bin": {
-        "partytown": "bin/partytown.cjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@renovatebot/pep440": {
@@ -6799,17 +6775,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dset": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
     "@astrojs/mdx": "^4.3.14",
-    "@astrojs/partytown": "^2.1.7",
     "@eslint/js": "^9.10.0",
     "@fontsource/inter-tight": "^5.2.7",
     "@fontsource/space-grotesk": "^5.2.10",

--- a/vendor/integration/index.ts
+++ b/vendor/integration/index.ts
@@ -26,7 +26,7 @@ export default ({ config: _themeConfig = 'src/config.yaml' } = {}): AstroIntegra
         const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
         const rawJsonConfig = (await loadConfig(_themeConfig)) as Config;
-        const { SITE, I18N, METADATA, APP_BLOG, UI, ANALYTICS } = configBuilder(rawJsonConfig);
+        const { SITE, I18N, METADATA, APP_BLOG, UI } = configBuilder(rawJsonConfig);
 
         updateConfig({
           site: SITE.site,
@@ -51,7 +51,6 @@ export default ({ config: _themeConfig = 'src/config.yaml' } = {}): AstroIntegra
                     export const METADATA = ${JSON.stringify(METADATA)};
                     export const APP_BLOG = ${JSON.stringify(APP_BLOG)};
                     export const UI = ${JSON.stringify(UI)};
-                    export const ANALYTICS = ${JSON.stringify(ANALYTICS)};
                     `;
                   }
                 },

--- a/vendor/integration/types.d.ts
+++ b/vendor/integration/types.d.ts
@@ -1,10 +1,9 @@
 declare module 'site:config' {
-  import type { SiteConfig, I18NConfig, MetaDataConfig, AppBlogConfig, UIConfig, AnalyticsConfig } from './config';
+  import type { SiteConfig, I18NConfig, MetaDataConfig, AppBlogConfig, UIConfig } from './config';
 
   export const SITE: SiteConfig;
   export const I18N: I18NConfig;
   export const METADATA: MetaDataConfig;
   export const APP_BLOG: AppBlogConfig;
   export const UI: UIConfig;
-  export const ANALYTICS: AnalyticsConfig;
 }

--- a/vendor/integration/types.d.ts
+++ b/vendor/integration/types.d.ts
@@ -1,5 +1,5 @@
 declare module 'site:config' {
-  import type { SiteConfig, I18NConfig, MetaDataConfig, AppBlogConfig, UIConfig } from './config';
+  import type { SiteConfig, I18NConfig, MetaDataConfig, AppBlogConfig, UIConfig } from './utils/configBuilder';
 
   export const SITE: SiteConfig;
   export const I18N: I18NConfig;

--- a/vendor/integration/utils/configBuilder.ts
+++ b/vendor/integration/utils/configBuilder.ts
@@ -10,7 +10,6 @@ export type Config = {
     blog?: AppBlogConfig;
   };
   ui?: unknown;
-  analytics?: unknown;
 };
 
 export interface SiteConfig {
@@ -69,18 +68,6 @@ export interface AppBlogConfig {
     };
   };
 }
-export interface AnalyticsConfig {
-  vendors: {
-    googleAnalytics: {
-      id?: string;
-      partytown?: boolean;
-    };
-    googleTagManager: {
-      id?: string;
-    };
-  };
-}
-
 export interface UIConfig {
   theme: string;
 }
@@ -183,27 +170,10 @@ const getUI = (config: Config) => {
   return merge({}, _default, config?.ui ?? {});
 };
 
-const getAnalytics = (config: Config) => {
-  const _default = {
-    vendors: {
-      googleAnalytics: {
-        id: undefined,
-        partytown: true,
-      },
-      googleTagManager: {
-        id: undefined,
-      },
-    },
-  };
-
-  return merge({}, _default, config?.analytics ?? {}) as AnalyticsConfig;
-};
-
 export default (config: Config) => ({
   SITE: getSite(config),
   I18N: getI18N(config),
   METADATA: getMetadata(config),
   APP_BLOG: getAppBlog(config),
   UI: getUI(config),
-  ANALYTICS: getAnalytics(config),
 });


### PR DESCRIPTION
## Summary

Follow-up cleanup from #85 (which removed GTM + GA entirely). Two related tear-downs of dead analytics surface, in two commits:

**1. `chore(analytics): remove dead Partytown integration`**

Partytown was only wired up to offload GTM's `dataLayer.push`. With GTM gone, its only consumer is gone.

- `astro.config.ts`: removed `partytown` import, `AstroIntegration` type import (only used by helper signature), `hasExternalScripts` / `whenExternalScripts` helper, and the Partytown registration in `integrations: [...]`.
- Uninstalled `@astrojs/partytown` from `package.json` + `package-lock.json`.

**2. `chore(analytics): remove dead AnalyticsConfig from vendor integration`**

The `AnalyticsConfig` type, `getAnalytics()` getter, and `ANALYTICS` virtual-module export in `vendor/integration/` had no consumers anywhere in `src/` — fully dead surface left behind by #85 + d60f975.

- `vendor/integration/utils/configBuilder.ts`: dropped the `AnalyticsConfig` interface, `getAnalytics()` function, `analytics?: unknown` field on the `Config` type, and `ANALYTICS` from the default export.
- `vendor/integration/index.ts`: dropped the `ANALYTICS` destructure and the `ANALYTICS` line in the `site:config` virtual-module emission.
- `vendor/integration/types.d.ts`: dropped the `ANALYTICS` declaration and `AnalyticsConfig` import.

Future Vercel Analytics work won't reuse this scaffolding (no IDs to configure, drop-in component, Partytown not applicable), so leaving the husk served no purpose.

## Verification

- `npm run check` (astro check + eslint, CI parity): **0 errors / 0 warnings**.
- No remaining `partytown` / `whenExternalScripts` / `dataLayer` / `ANALYTICS` / `AnalyticsConfig` / `getAnalytics` references anywhere in the repo.

## Test plan

- [ ] `git pull && npm ci` succeeds
- [ ] `npm run dev` starts the dev server cleanly
- [ ] `npm run build` succeeds
- [ ] No `partytown` references in the build output (`dist/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)