### PR TITLE
chore(layout): hide Anna announcement banner until feature ships

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -2,7 +2,6 @@
 import Layout from '~/layouts/Layout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Footer from '~/components/widgets/Footer.astro';
-import Announcement from '~/components/widgets/Announcement.astro';
 
 import { headerData, footerData } from '~/navigation';
 
@@ -16,9 +15,7 @@ const { metadata } = Astro.props;
 ---
 
 <Layout metadata={metadata}>
-  <slot name="announcement">
-    <Announcement />
-  </slot>
+  <slot name="announcement" />
   <slot name="header">
     <Header {...headerData} isSticky showRssFeed showToggleTheme />
   </slot>


### PR DESCRIPTION
## Summary

- Stop rendering `<Announcement />` from `PageLayout.astro`. The Anna phone-agent invite was appearing site-wide even though the feature is still aspirational.
- Keep the `announcement` named slot in place so individual pages can opt back in by passing slot content.
- Leave [src/components/widgets/Announcement.astro](../blob/chore/hide-anna-announcement/src/components/widgets/Announcement.astro) intact — re-enabling is a one-line change in `PageLayout.astro` once Anna actually ships.

## Test plan

- [x] `npm run check` (astro check + eslint) — clean
- [ ] Visual smoke: dev server shows no banner above the header on home and any inner page
- [ ] Confirm no other component imports `Announcement` (verified via grep — only `PageLayout.astro` did)

🤖 Generated with [Claude Code](https://claude.com/claude-code)