### PR TITLE
release: dev → main (hide Anna announcement banner)

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -2,7 +2,6 @@
 import Layout from '~/layouts/Layout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Footer from '~/components/widgets/Footer.astro';
-import Announcement from '~/components/widgets/Announcement.astro';
 
 import { headerData, footerData } from '~/navigation';
 
@@ -16,9 +15,7 @@ const { metadata } = Astro.props;
 ---
 
 <Layout metadata={metadata}>
-  <slot name="announcement">
-    <Announcement />
-  </slot>
+  <slot name="announcement" />
   <slot name="header">
     <Header {...headerData} isSticky showRssFeed showToggleTheme />
   </slot>


### PR DESCRIPTION
## Summary

Promotes the Anna announcement-banner removal from `dev` to `main`.

- #93 — `chore(layout): hide Anna announcement banner until feature ships`. Stops rendering `<Announcement />` from `PageLayout.astro`. The named `announcement` slot stays in place and the component file is preserved, so re-enabling is a one-line change once Anna ships.

## Commits in this release

- `4f7637c` chore(layout): hide Anna announcement banner until feature ships (#93)
- `d74f757` chore(layout): stop rendering Anna announcement banner

## Test plan

- [x] `npm run check` clean on the source PR
- [ ] Production deploy renders no banner above the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)